### PR TITLE
Add `reportUnusedDisableDirectives` option to `svelte/comment-directive` rule

### DIFF
--- a/docs/rules/comment-directive.md
+++ b/docs/rules/comment-directive.md
@@ -64,7 +64,41 @@ The `eslint-disable`-like comments can include descriptions to explain why the c
 
 ## :wrench: Options
 
-Nothing.
+```json
+{
+  "svelte/comment-directive": [
+    "error",
+    {
+      "reportUnusedDisableDirectives": false
+    }
+  ]
+}
+```
+
+- `reportUnusedDisableDirectives` ... If `true`, to report unused `eslint-disable` HTML comments. default `false`
+
+### `{ "reportUnusedDisableDirectives": true }`
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/comment-directive: ["error", { "reportUnusedDisableDirectives": true }], no-undef: "error" */
+  import DefinedComponent from "./DefinedComponent.svelte"
+</script>
+
+<!-- ✓ GOOD -->
+<!-- eslint-disable-next-line no-undef -->
+<UndefComponent />
+
+<!-- ✗ BAD -->
+<!-- eslint-disable-next-line no-undef -->
+<DefinedComponent />
+```
+
+</ESLintCodeBlock>
 
 ## :books: Further Reading
 

--- a/src/rules/comment-directive.ts
+++ b/src/rules/comment-directive.ts
@@ -44,7 +44,14 @@ export default createRule("comment-directive", {
         additionalProperties: false,
       },
     ],
-    messages: {},
+    messages: {
+      unused: "Unused {{kind}} directive (no problems were reported).",
+      unusedRule:
+        "Unused {{kind}} directive (no problems were reported from '{{rule}}').",
+      unusedEnable: "Unused {{kind}} directive (reporting is not suppressed).",
+      unusedEnableRule:
+        "Unused {{kind}} directive (reporting from '{{rule}}' is not suppressed).",
+    },
     type: "problem",
   },
   create(context) {
@@ -121,7 +128,7 @@ export default createRule("comment-directive", {
                   data: { rule: rule.ruleId, kind: parsed.type },
                 })
               }
-              directives.disableBlock(comment.loc.start, rule.ruleId, {
+              directives.disableBlock(comment.loc.end, rule.ruleId, {
                 loc: rule.loc.start,
               })
             }
@@ -133,7 +140,7 @@ export default createRule("comment-directive", {
                 data: { kind: parsed.type },
               })
             }
-            directives.disableBlock(comment.loc.start, ALL_RULES, {
+            directives.disableBlock(comment.loc.end, ALL_RULES, {
               loc: comment.loc.start,
             })
           }
@@ -143,7 +150,7 @@ export default createRule("comment-directive", {
               if (reportUnusedDisableDirectives) {
                 context.report({
                   loc: rule.loc,
-                  messageId: "unusedRule",
+                  messageId: "unusedEnableRule",
                   data: { rule: rule.ruleId, kind: parsed.type },
                 })
               }
@@ -155,7 +162,7 @@ export default createRule("comment-directive", {
             if (reportUnusedDisableDirectives) {
               context.report({
                 loc: comment.loc,
-                messageId: "unused",
+                messageId: "unusedEnable",
                 data: { kind: parsed.type },
               })
             }

--- a/tests/src/rules/comment-directive.ts
+++ b/tests/src/rules/comment-directive.ts
@@ -347,171 +347,203 @@ describe("comment-directive", () => {
     })
   })
 
-  // describe("reportUnusedDisableDirectives", () => {
-  //   const linter = new eslint.CLIEngine({
-  //     parser: require.resolve("vue-eslint-parser"),
-  //     parserOptions: {
-  //       ecmaVersion: 2015,
-  //     },
-  //     plugins: ["vue"],
-  //     rules: {
-  //       "no-unused-vars": "error",
-  //       "vue/comment-directive": [
-  //         "error",
-  //         { reportUnusedDisableDirectives: true },
-  //       ],
-  //       "svelte/no-at-html-tags": "error",
-  //       "space-infix-ops": "error",
-  //     },
-  //     useEslintrc: false,
-  //   })
-  //   it("report unused <!-- eslint-disable -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable -->
-  //          <div id="a">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+  describe("reportUnusedDisableDirectives", () => {
+    const linter = new eslint.ESLint({
+      plugins: {
+        svelte: plugin as never,
+      },
+      baseConfig: {
+        parser: require.resolve("svelte-eslint-parser"),
+        parserOptions: {
+          ecmaVersion: 2015,
+        },
+        plugins: ["svelte"],
+        rules: {
+          "no-unused-vars": "error",
+          "svelte/comment-directive": [
+            "error",
+            { reportUnusedDisableDirectives: true },
+          ],
+          "svelte/no-at-html-tags": "error",
+          "svelte/no-at-debug-tags": "error",
+        },
+      },
+      useEslintrc: false,
+    })
+    it("report unused <!-- eslint-disable -->", async () => {
+      const code = `
+        <!-- eslint-disable -->
+        <div>Hello</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 1)
-  //     assert.strictEqual(messages[0].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[0].message,
-  //       "Unused eslint-disable directive (no problems were reported).",
-  //     )
-  //     assert.strictEqual(messages[0].line, 3)
-  //     assert.strictEqual(messages[0].column, 11)
-  //   })
+      assert.strictEqual(messages.length, 1)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-disable directive (no problems were reported).",
+      )
+      assert.strictEqual(messages[0].line, 2)
+      assert.strictEqual(messages[0].column, 9)
+    })
 
-  //   it("dont report unused <!-- eslint-disable -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable -->
-  //          <div id id="a">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+    it("dont report unused <!-- eslint-disable -->", async () => {
+      const code = `
+        <!-- eslint-disable -->
+        <div>{@html foo}{@debug foo}</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 0)
-  //   })
-  //   it("disable and report unused <!-- eslint-disable -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable -->
-  //          <div id id="a">Hello</div>
-  //          <!-- eslint-enable -->
-  //          <!-- eslint-disable -->
-  //          <div id="b">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+      assert.strictEqual(messages.length, 0)
+    })
+    it("disable and report unused <!-- eslint-disable -->", async () => {
+      const code = `
+        <!-- eslint-disable -->
+        <div>{@html foo}{@debug foo}</div>
+        <!-- eslint-enable -->
+        <!-- eslint-disable -->
+        <div>Hello</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 1)
-  //     assert.strictEqual(messages[0].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[0].message,
-  //       "Unused eslint-disable directive (no problems were reported).",
-  //     )
-  //     assert.strictEqual(messages[0].line, 6)
-  //     assert.strictEqual(messages[0].column, 11)
-  //   })
+      assert.strictEqual(messages.length, 1)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-disable directive (no problems were reported).",
+      )
+      assert.strictEqual(messages[0].line, 5)
+      assert.strictEqual(messages[0].column, 9)
+    })
 
-  //   it("report unused <!-- eslint-disable space-infix-ops, svelte/no-at-html-tags -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable space-infix-ops, svelte/no-at-html-tags -->
-  //          <div id="a">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+    it("report unused <!-- eslint-disable svelte/no-at-debug-tags, svelte/no-at-html-tags -->", async () => {
+      const code = `
+        <!-- eslint-disable svelte/no-at-debug-tags, svelte/no-at-html-tags -->
+        <div>Hello</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 2)
+      assert.strictEqual(messages.length, 2)
 
-  //     assert.strictEqual(messages[0].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[0].message,
-  //       "Unused eslint-disable directive (no problems were reported from 'space-infix-ops').",
-  //     )
-  //     assert.strictEqual(messages[0].line, 3)
-  //     assert.strictEqual(messages[0].column, 31)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-disable directive (no problems were reported from 'svelte/no-at-debug-tags').",
+      )
+      assert.strictEqual(messages[0].line, 2)
+      assert.strictEqual(messages[0].column, 29)
 
-  //     assert.strictEqual(messages[1].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[1].message,
-  //       "Unused eslint-disable directive (no problems were reported from 'svelte/no-at-html-tags').",
-  //     )
-  //     assert.strictEqual(messages[1].line, 3)
-  //     assert.strictEqual(messages[1].column, 60)
-  //   })
+      assert.strictEqual(messages[1].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[1].message,
+        "Unused eslint-disable directive (no problems were reported from 'svelte/no-at-html-tags').",
+      )
+      assert.strictEqual(messages[1].line, 2)
+      assert.strictEqual(messages[1].column, 54)
+    })
 
-  //   it("report unused <!-- eslint-disable-next-line space-infix-ops, svelte/no-at-html-tags -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable-next-line space-infix-ops, svelte/no-at-html-tags -->
-  //          <div id="a">Hello</div>
-  //          <div id id="b">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+    it("report unused <!-- eslint-disable-next-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->", async () => {
+      const code = `
+        <!-- eslint-disable-next-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->
+        <div>Hello</div>
+        <div>{@html foo}{@debug foo}</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 4)
+      assert.strictEqual(messages.length, 4)
 
-  //     assert.strictEqual(messages[0].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[0].message,
-  //       "Unused eslint-disable-next-line directive (no problems were reported from 'space-infix-ops').",
-  //     )
-  //     assert.strictEqual(messages[0].line, 3)
-  //     assert.strictEqual(messages[0].column, 41)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-disable-next-line directive (no problems were reported from 'svelte/no-at-debug-tags').",
+      )
+      assert.strictEqual(messages[0].line, 2)
+      assert.strictEqual(messages[0].column, 39)
 
-  //     assert.strictEqual(messages[1].ruleId, "vue/comment-directive")
-  //     assert.strictEqual(
-  //       messages[1].message,
-  //       "Unused eslint-disable-next-line directive (no problems were reported from 'svelte/no-at-html-tags').",
-  //     )
-  //     assert.strictEqual(messages[1].line, 3)
-  //     assert.strictEqual(messages[1].column, 70)
+      assert.strictEqual(messages[1].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[1].message,
+        "Unused eslint-disable-next-line directive (no problems were reported from 'svelte/no-at-html-tags').",
+      )
+      assert.strictEqual(messages[1].line, 2)
+      assert.strictEqual(messages[1].column, 64)
 
-  //     assert.strictEqual(
-  //       messages[2].ruleId,
-  //       "svelte/no-at-html-tags",
-  //     )
-  //     assert.strictEqual(messages[2].line, 5)
-  //     assert.strictEqual(messages[3].ruleId, "space-infix-ops")
-  //     assert.strictEqual(messages[3].line, 5)
-  //   })
+      assert.strictEqual(messages[2].ruleId, "svelte/no-at-html-tags")
+      assert.strictEqual(messages[2].line, 4)
+      assert.strictEqual(messages[3].ruleId, "svelte/no-at-debug-tags")
+      assert.strictEqual(messages[3].line, 4)
+    })
 
-  //   it("dont report used <!-- eslint-disable-next-line space-infix-ops, svelte/no-at-html-tags -->", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable-next-line space-infix-ops, svelte/no-at-html-tags -->
-  //          <div id id="a">Hello</div>
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+    it("dont report used <!-- eslint-disable-next-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->", async () => {
+      const code = `
+        <!-- eslint-disable-next-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->
+        <div>{@html foo}{@debug foo}</div>
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 0)
-  //   })
+      assert.deepStrictEqual(messages, [])
+    })
 
-  //   it("dont report used, with duplicate eslint-disable", () => {
-  //     const code = `
-  //        <template>
-  //          <!-- eslint-disable -->
-  //          <!-- eslint-disable-next-line space-infix-ops, svelte/no-at-html-tags -->
-  //          <div id id="a">Hello</div><!-- eslint-disable-line space-infix-ops, svelte/no-at-html-tags -->
-  //        </template>
-  //      `
-  //     const messages = linter.executeOnText(code, "test.vue").results[0]
-  //       .messages
+    it("dont report used, with duplicate eslint-disable", async () => {
+      const code = `
+        <!-- eslint-disable -->
+        <!-- eslint-disable-next-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->
+        <div>{@html foo}</div><!-- eslint-disable-line svelte/no-at-debug-tags, svelte/no-at-html-tags -->
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
 
-  //     assert.strictEqual(messages.length, 0)
-  //   })
-  // })
+      assert.deepStrictEqual(messages, [])
+    })
+
+    it("report unused <!-- eslint-enable -->", async () => {
+      const code = `
+        <!-- eslint-enable -->
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
+
+      assert.strictEqual(messages.length, 1)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-enable directive (reporting is not suppressed).",
+      )
+      assert.strictEqual(messages[0].line, 2)
+      assert.strictEqual(messages[0].column, 9)
+    })
+    it("report unused <!-- eslint-enable svelte/no-at-debug-tags -->", async () => {
+      const code = `
+        <!-- eslint-disable svelte/no-at-html-tags -->
+        <div>{@html foo}</div>
+        <!-- eslint-enable svelte/no-at-debug-tags -->
+      `
+      const messages = (
+        await linter.lintText(code, { filePath: "test.svelte" })
+      )[0].messages
+
+      assert.strictEqual(messages.length, 1)
+      assert.strictEqual(messages[0].ruleId, "svelte/comment-directive")
+      assert.strictEqual(
+        messages[0].message,
+        "Unused eslint-enable directive (reporting from 'svelte/no-at-debug-tags' is not suppressed).",
+      )
+      assert.strictEqual(messages[0].line, 4)
+      assert.strictEqual(messages[0].column, 28)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds `reportUnusedDisableDirectives` option to `svelte/comment-directive` rule.

---

I had implemented this option halfway, but I realized I didn't finish the implementation 😓.



