### PR TITLE
Chore: fixed ver of `@sveltejs/kit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@ota-meshi/eslint-plugin": "^0.11.0",
     "@sindresorhus/slugify": "^2.1.0",
     "@sveltejs/adapter-static": "^1.0.0-next.26",
-    "@sveltejs/kit": "^1.0.0-next.240",
+    "@sveltejs/kit": "1.0.0-next.358",
     "@types/babel__core": "^7.1.19",
     "@types/eslint": "^8.0.0",
     "@types/eslint-scope": "^3.7.0",

--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,6 @@
       "depTypeList": ["devDependencies"],
       "automerge": true
     }
-  ]
+  ],
+  "ignoreDeps": ["@sveltejs/kit"]
 }


### PR DESCRIPTION
This PR fixes the version of `@sveltejs/kit` as a workaround for the site build error.

It takes time to work to upgrade the version.