### PR TITLE
feat: indent/indentScript option

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -88,6 +88,7 @@ This rule only checks `.svelte` files and does not interfere with other `.js` fi
 ```
 
 - `indent` (`number | "tab"`) ... The type of indentation. Default is `2`. If this is a number, it's the number of spaces for one indent. If this is `"tab"`, it uses one tab for one indent.
+- `indentScript` (`boolean`) ... If contents within a `<script>` block should be indented a level or not. Default is `true`.
 - `ignoredNodes` ... Can be used to disable indentation checking for any AST node. This accepts an array of [selectors](https://eslint.org/docs/developer-guide/selectors). If an AST node is matched by any of the selectors, the indentation of tokens which are direct children of that node will be ignored. This can be used as an escape hatch to relax the rule if you disagree with the indentation that it enforces for a particular syntactic pattern.
 - `switchCase` ... Enforces indentation level for case clauses in switch statements. Default is `1`.
 - `alignAttributesVertically` ... Condition for whether attributes should be vertically aligned to the first attribute in multiline case or not. Default is `false`

--- a/src/rules/indent-helpers/commons.ts
+++ b/src/rules/indent-helpers/commons.ts
@@ -13,6 +13,7 @@ export type MaybeNode = {
 
 export type IndentOptions = {
   indentChar: " " | "\t"
+  indentScript: boolean
   indentSize: number
   switchCase: number
   alignAttributesVertically: boolean

--- a/src/rules/indent-helpers/index.ts
+++ b/src/rules/indent-helpers/index.ts
@@ -12,6 +12,7 @@ import { OffsetContext } from "./offset-context"
 
 type IndentUserOptions = {
   indent?: number | "tab"
+  indentScript?: boolean
   switchCase?: number
   alignAttributesVertically?: boolean
   ignoredNodes?: string[]
@@ -30,6 +31,7 @@ function parseOptions(
 ): IndentOptions {
   const ret: IndentOptions = {
     indentChar: " ",
+    indentScript: true,
     indentSize: 2,
     switchCase: 1,
     alignAttributesVertically: false,
@@ -42,6 +44,10 @@ function parseOptions(
   } else if (options.indent === "tab") {
     ret.indentChar = "\t"
     ret.indentSize = 1
+  }
+
+  if (typeof options.indentScript === "boolean") {
+    ret.indentScript = options.indentScript
   }
 
   if (options.switchCase != null && Number.isSafeInteger(options.switchCase)) {

--- a/src/rules/indent-helpers/svelte.ts
+++ b/src/rules/indent-helpers/svelte.ts
@@ -23,7 +23,12 @@ export function defineVisitor(context: IndentContext): NodeListener {
     // ELEMENTS
     // ----------------------------------------------------------------------
     SvelteScriptElement(node: AST.SvelteScriptElement) {
-      offsets.setOffsetElementList(node.body, node.startTag, node.endTag, 1)
+      offsets.setOffsetElementList(
+        node.body,
+        node.startTag,
+        node.endTag,
+        options.indentScript ? 1 : 0,
+      )
     },
     SvelteStyleElement(node: AST.SvelteStyleElement) {
       node.children.forEach((n) => offsets.ignore(n))
@@ -38,7 +43,7 @@ export function defineVisitor(context: IndentContext): NodeListener {
             node.children.filter(isNotEmptyTextNode),
             node.startTag,
             node.endTag,
-            1,
+            options.indentScript ? 1 : 0,
           )
         }
       } else {

--- a/src/rules/indent-helpers/svelte.ts
+++ b/src/rules/indent-helpers/svelte.ts
@@ -43,7 +43,7 @@ export function defineVisitor(context: IndentContext): NodeListener {
             node.children.filter(isNotEmptyTextNode),
             node.startTag,
             node.endTag,
-            options.indentScript ? 1 : 0,
+            1,
           )
         }
       } else {

--- a/src/rules/indent.ts
+++ b/src/rules/indent.ts
@@ -16,6 +16,7 @@ export default createRule("indent", {
           indent: {
             anyOf: [{ type: "integer", minimum: 1 }, { enum: ["tab"] }],
           },
+          indentScript: { type: "boolean" },
           switchCase: { type: "integer", minimum: 0 },
           alignAttributesVertically: { type: "boolean" },
           ignoredNodes: {

--- a/tests/fixtures/rules/indent/invalid/indent-script/_config.json
+++ b/tests/fixtures/rules/indent/invalid/indent-script/_config.json
@@ -1,0 +1,3 @@
+{
+  "options": [{ "indentScript": false }]
+}

--- a/tests/fixtures/rules/indent/invalid/indent-script/indent-script-errors.json
+++ b/tests/fixtures/rules/indent/invalid/indent-script/indent-script-errors.json
@@ -1,0 +1,7 @@
+[
+  {
+    "message": "Expected indentation of 0 spaces but found 2 spaces.",
+    "line": 3,
+    "column": 1
+  }
+]

--- a/tests/fixtures/rules/indent/invalid/indent-script/indent-script-input.svelte
+++ b/tests/fixtures/rules/indent/invalid/indent-script/indent-script-input.svelte
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+<script>
+  const a = "indent-script-input.svelte"
+</script>

--- a/tests/fixtures/rules/indent/invalid/indent-script/indent-script-output.svelte
+++ b/tests/fixtures/rules/indent/invalid/indent-script/indent-script-output.svelte
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+<script>
+const a = "indent-script-input.svelte"
+</script>

--- a/tests/fixtures/rules/indent/valid/indent-script-input.svelte
+++ b/tests/fixtures/rules/indent/valid/indent-script-input.svelte
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+<script>
+  const a = "indent-script-input.svelte"
+</script>


### PR DESCRIPTION
Allows for configuring whether the contents of `<script>` blocks should be indented a single tabstop or not. Defaults to `true` for back-compat.

Fixes #155 