### PR TITLE
Chore: update `@sveltejs/kit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "yarn clean && yarn build",
     "pretest:base": "cross-env DEBUG=eslint-plugin-svelte*",
     "preversion": "yarn test && git add .",
-    "svelte-kit": "node --experimental-loader ./svelte-kit-import-hook.mjs node_modules/@sveltejs/kit/svelte-kit.js",
+    "svelte-kit": "node --experimental-loader ./svelte-kit-import-hook.mjs node_modules/vite/bin/vite.js --config vite.config.mjs",
     "test": "yarn mocha \"tests/src/**/*.ts\" --reporter dot --timeout 60000",
     "ts": "node -r esbuild-register",
     "update": "yarn ts ./tools/update.ts && yarn format-for-gen-file",
@@ -77,7 +77,7 @@
     "@ota-meshi/eslint-plugin": "^0.11.0",
     "@sindresorhus/slugify": "^2.1.0",
     "@sveltejs/adapter-static": "^1.0.0-next.26",
-    "@sveltejs/kit": "1.0.0-next.358",
+    "@sveltejs/kit": "^1.0.0-next.360",
     "@types/babel__core": "^7.1.19",
     "@types/eslint": "^8.0.0",
     "@types/eslint-scope": "^3.7.0",
@@ -134,6 +134,7 @@
     "svelte": "^3.46.1",
     "svelte-adapter-ghpages": "0.0.2",
     "typescript": "^4.5.2",
+    "vite": "^2.9.13",
     "vite-plugin-svelte-md": "^0.1.3"
   },
   "publishConfig": {

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,5 @@
       "depTypeList": ["devDependencies"],
       "automerge": true
     }
-  ],
-  "ignoreDeps": ["@sveltejs/kit"]
+  ]
 }

--- a/svelte.config.esm.mjs
+++ b/svelte.config.esm.mjs
@@ -1,10 +1,6 @@
 /* global __dirname, URL -- __dirname, URL */
 import ghpagesAdapter from "svelte-adapter-ghpages"
 import path from "path"
-import svelteMd from "vite-plugin-svelte-md"
-import svelteMdOption from "./docs-svelte-kit/tools/vite-plugin-svelte-md-option.mjs"
-
-import "./docs-svelte-kit/build-system/build.js"
 
 const dirname =
   typeof __dirname !== "undefined"
@@ -41,46 +37,6 @@ const config = {
     },
 
     trailingSlash: "always",
-
-    vite: {
-      server: {
-        fs: { strict: false },
-      },
-      resolve: {
-        alias: {
-          eslint: path.join(dirname, "./docs-svelte-kit/shim/eslint.mjs"),
-          assert: path.join(dirname, "./docs-svelte-kit/shim/assert.mjs"),
-          "postcss-load-config": path.join(
-            dirname,
-            "./docs-svelte-kit/shim/postcss-load-config.mjs",
-          ),
-          "source-map-js": path.join(
-            dirname,
-            "./docs-svelte-kit/shim/source-map-js.mjs",
-          ),
-          module: path.join(dirname, "./docs-svelte-kit/shim/module.mjs"),
-          path: path.join(dirname, "./docs-svelte-kit/shim/path.mjs"),
-          url: path.join(dirname, "./docs-svelte-kit/shim/url.mjs"),
-          os: path.join(dirname, "./docs-svelte-kit/shim/os.mjs"),
-          fs: path.join(dirname, "./docs-svelte-kit/shim/fs.mjs"),
-          globby: path.join(dirname, "./docs-svelte-kit/shim/globby.mjs"),
-          tslib: path.join(dirname, "./node_modules/tslib/tslib.es6.js"),
-        },
-      },
-      plugins: [
-        svelteMd(
-          svelteMdOption({
-            baseUrl: "/eslint-plugin-svelte",
-            root: path.join(dirname, "./docs"),
-          }),
-        ),
-      ],
-      build: {
-        commonjsOptions: {
-          ignoreDynamicRequires: true,
-        },
-      },
-    },
   },
 }
 export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2020",
     "module": "commonjs",
     "lib": ["es2020", "dom"],
     "allowJs": true,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,53 @@
+/* global URL -- URL */
+import { sveltekit } from "@sveltejs/kit/vite"
+import path from "path"
+import svelteMd from "vite-plugin-svelte-md"
+import svelteMdOption from "./docs-svelte-kit/tools/vite-plugin-svelte-md-option.mjs"
+
+import "./docs-svelte-kit/build-system/build.js"
+
+const dirname = path.dirname(new URL(import.meta.url).pathname)
+
+/** @type {import('vite').UserConfig} */
+const config = {
+  plugins: [
+    svelteMd(
+      svelteMdOption({
+        baseUrl: "/eslint-plugin-svelte",
+        root: path.join(dirname, "./docs"),
+      }),
+    ),
+    sveltekit(),
+  ],
+  server: {
+    fs: { strict: false },
+  },
+  resolve: {
+    alias: {
+      eslint: path.join(dirname, "./docs-svelte-kit/shim/eslint.mjs"),
+      assert: path.join(dirname, "./docs-svelte-kit/shim/assert.mjs"),
+      "postcss-load-config": path.join(
+        dirname,
+        "./docs-svelte-kit/shim/postcss-load-config.mjs",
+      ),
+      "source-map-js": path.join(
+        dirname,
+        "./docs-svelte-kit/shim/source-map-js.mjs",
+      ),
+      module: path.join(dirname, "./docs-svelte-kit/shim/module.mjs"),
+      path: path.join(dirname, "./docs-svelte-kit/shim/path.mjs"),
+      url: path.join(dirname, "./docs-svelte-kit/shim/url.mjs"),
+      os: path.join(dirname, "./docs-svelte-kit/shim/os.mjs"),
+      fs: path.join(dirname, "./docs-svelte-kit/shim/fs.mjs"),
+      globby: path.join(dirname, "./docs-svelte-kit/shim/globby.mjs"),
+      tslib: path.join(dirname, "./node_modules/tslib/tslib.es6.js"),
+    },
+  },
+  build: {
+    commonjsOptions: {
+      ignoreDynamicRequires: true,
+    },
+  },
+}
+
+export default config


### PR DESCRIPTION
This PR updates the version of `@sveltejs/kit`. Related to #179.  
The way `@sveltejs/kit` is configured has changed so much that the configuration file has changed.