### PR TITLE
Add `plugin:svelte/prettier` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This plugin provides configs:
 
 - `plugin:svelte/base` ... Configuration to enable correct Svelte parsing.
 - `plugin:svelte/recommended` ... Above, plus rules to prevent errors or unintended behavior.
+- `plugin:svelte/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/) ([prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte)).
 
 See [the rule list](https://ota-meshi.github.io/eslint-plugin-svelte/rules/) to get the `rules` that this plugin provides.
 
@@ -360,7 +361,7 @@ If you want to test only one rule, run the following command (for `indent` rule)
 yarn test -g indent
 ```
 
-Take https://stackoverflow.com/questions/10832031/how-to-run-a-single-test-with-mocha as reference for details.
+Take <https://stackoverflow.com/questions/10832031/how-to-run-a-single-test-with-mocha> as reference for details.
 
 If you want to test only `my-test-input.svelte`, add `my-test-config.json` and save `{"only": true}`.  
 (Note that `{"only": true}` must be removed before making a pull request.)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,6 +41,7 @@ This plugin provides configs:
 
 - `plugin:svelte/base` ... Configuration to enable correct Svelte parsing.
 - `plugin:svelte/recommended` ... Above, plus rules to prevent errors or unintended behavior.
+- `plugin:svelte/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/) ([prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte)).
 
 See [the rule list](./rules.md) to get the `rules` that this plugin provides.
 

--- a/src/configs/prettier.ts
+++ b/src/configs/prettier.ts
@@ -1,0 +1,17 @@
+import path from "path"
+const base = require.resolve("./base")
+const baseExtend =
+  path.extname(`${base}`) === ".ts" ? "plugin:svelte/base" : base
+export = {
+  extends: [baseExtend],
+  rules: {
+    // eslint-plugin-svelte rules
+    "svelte/first-attribute-linebreak": "off",
+    "svelte/html-quotes": "off",
+    "svelte/indent": "off",
+    "svelte/max-attributes-per-line": "off",
+    "svelte/mustache-spacing": "off",
+    "svelte/shorthand-attribute": "off",
+    "svelte/shorthand-directive": "off",
+  },
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import type { RuleModule } from "./types"
 import { rules as ruleList } from "./utils/rules"
 import base from "./configs/base"
 import recommended from "./configs/recommended"
+import prettier from "./configs/prettier"
 import * as processor from "./processor"
 
 const configs = {
   base,
   recommended,
+  prettier,
 }
 
 const rules = ruleList.reduce((obj, r) => {

--- a/src/rules/first-attribute-linebreak.ts
+++ b/src/rules/first-attribute-linebreak.ts
@@ -7,6 +7,7 @@ export default createRule("first-attribute-linebreak", {
       description: "enforce the location of first attribute",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "whitespace",
     schema: [

--- a/src/rules/html-quotes.ts
+++ b/src/rules/html-quotes.ts
@@ -20,6 +20,7 @@ export default createRule("html-quotes", {
       description: "enforce quotes style of HTML attributes",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "code",
     schema: [

--- a/src/rules/indent.ts
+++ b/src/rules/indent.ts
@@ -7,6 +7,7 @@ export default createRule("indent", {
       description: "enforce consistent indentation",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "whitespace",
     schema: [

--- a/src/rules/max-attributes-per-line.ts
+++ b/src/rules/max-attributes-per-line.ts
@@ -30,6 +30,7 @@ export default createRule("max-attributes-per-line", {
       description: "enforce the maximum number of attributes per line",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "whitespace",
     schema: [

--- a/src/rules/mustache-spacing.ts
+++ b/src/rules/mustache-spacing.ts
@@ -39,6 +39,7 @@ export default createRule("mustache-spacing", {
       description: "enforce unified spacing in mustache",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "code",
     schema: [

--- a/src/rules/prefer-class-directive.ts
+++ b/src/rules/prefer-class-directive.ts
@@ -14,6 +14,7 @@ export default createRule("prefer-class-directive", {
       description: "require class directives instead of ternary expressions",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: false,
     },
     fixable: "code",
     schema: [],

--- a/src/rules/prefer-style-directive.ts
+++ b/src/rules/prefer-style-directive.ts
@@ -23,6 +23,7 @@ export default createRule("prefer-style-directive", {
       description: "require style directives instead of style attribute",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: false,
     },
     fixable: "code",
     schema: [],

--- a/src/rules/shorthand-attribute.ts
+++ b/src/rules/shorthand-attribute.ts
@@ -7,6 +7,7 @@ export default createRule("shorthand-attribute", {
       description: "enforce use of shorthand syntax in attribute",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "code",
     schema: [

--- a/src/rules/shorthand-directive.ts
+++ b/src/rules/shorthand-directive.ts
@@ -8,6 +8,7 @@ export default createRule("shorthand-directive", {
       description: "enforce use of shorthand syntax in directives",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: true,
     },
     fixable: "code",
     schema: [

--- a/src/rules/spaced-html-comment.ts
+++ b/src/rules/spaced-html-comment.ts
@@ -7,6 +7,7 @@ export default createRule("spaced-html-comment", {
         "enforce consistent spacing after the `<!--` and before the `-->` in a HTML comment",
       category: "Stylistic Issues",
       recommended: false,
+      conflictWithPrettier: false,
     },
     fixable: "whitespace",
     schema: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export interface RuleMetaData {
     ruleId: string
     ruleName: string
     default?: "error" | "warn"
+    conflictWithPrettier?: boolean
   }
   messages: { [messageId: string]: string }
   fixable?: "code" | "whitespace"
@@ -82,11 +83,19 @@ export interface PartialRuleModule {
 export interface PartialRuleMetaData {
   docs: {
     description: string
-    category: RuleCategory
     recommended: boolean | "base"
     extensionRule?: string
     default?: "error" | "warn"
-  }
+  } & (
+    | {
+        category: Exclude<RuleCategory, "Stylistic Issues">
+        conflictWithPrettier?: boolean
+      }
+    | {
+        category: "Stylistic Issues"
+        conflictWithPrettier: boolean
+      }
+  )
   messages: { [messageId: string]: string }
   fixable?: "code" | "whitespace"
   schema: JSONSchema4 | JSONSchema4[]

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -62,7 +62,23 @@ const recommendedFilePath = path.resolve(
 // Update file.
 fs.writeFileSync(recommendedFilePath, recommendedContent)
 
-// Format files.
-// const linter = new eslint.CLIEngine({ fix: true })
-// const report = linter.executeOnFiles([filePath])
-// eslint.CLIEngine.outputFixes(report)
+const prettierContent = `import path from "path"
+const base = require.resolve("./base")
+const baseExtend =
+  path.extname(\`\${base}\`) === ".ts" ? "plugin:svelte/base" : base
+export = {
+  extends: [baseExtend],
+  rules: {
+    // eslint-plugin-svelte rules
+    ${rules
+      .filter((rule) => rule.meta.docs.conflictWithPrettier)
+      .map((rule) => `"${rule.meta.docs.ruleId}": "off"`)
+      .join(",\n    ")},
+  },
+}
+`
+
+const prettierFilePath = path.resolve(__dirname, "../src/configs/prettier.ts")
+
+// Update file.
+fs.writeFileSync(prettierFilePath, prettierContent)


### PR DESCRIPTION
This PR adds `plugin:svelte/prettier` config that turns off rules that conflict with prettier-plugin-svelte. 