### PR TITLE
Docs: Fix playground width

### DIFF
--- a/docs-svelte-kit/src/lib/components/ESLintPlayground.svelte
+++ b/docs-svelte-kit/src/lib/components/ESLintPlayground.svelte
@@ -211,6 +211,10 @@
 </div>
 
 <style>
+  :global(.main-content) {
+    max-width: 100% !important;
+  }
+
   .playground-root {
     height: calc(100vh - 180px);
   }


### PR DESCRIPTION
Now playground width is too narorow.
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/19153718/179386466-a984c8fa-f69d-49f4-bb90-dd6c65a42b51.png">

To fix this issue, we need to override the layout svelte file's CSS in some way.
However, I could not figure out how to do it because of the markdown involved.
So I used `:global` to solve this issue.

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/19153718/179386507-4c4c64d1-2ff7-427c-a194-85934e1aff29.png">

I could not find a way not to use `!important`.