### PR TITLE
Fix false positives for files other than `*.svelte` in `svelte/no-unused-svelte-ignore` rule

### DIFF
--- a/src/rules/no-unused-svelte-ignore.ts
+++ b/src/rules/no-unused-svelte-ignore.ts
@@ -19,6 +19,9 @@ export default createRule("no-unused-svelte-ignore", {
   },
 
   create(context) {
+    if (!context.parserServices.isSvelte) {
+      return {}
+    }
     const sourceCode = context.getSourceCode()
 
     const ignoreComments: IgnoreItem[] = []

--- a/tests/fixtures/rules/no-unused-svelte-ignore/valid/ignore-js-input.js
+++ b/tests/fixtures/rules/no-unused-svelte-ignore/valid/ignore-js-input.js
@@ -1,0 +1,4 @@
+// <!-- svelte-ignore a11y-autofocus a11y-missing-attribute -->
+// <img src="foo" alt="Foo" />
+/* svelte-ignore a11y-autofocus a11y-missing-attribute */
+// <img src="foo" />

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -233,9 +233,6 @@ function getConfig(ruleName: string, inputFile: string) {
     path.extname(filename) === ".svelte"
       ? require.resolve("svelte-eslint-parser")
       : undefined
-  if (config && typeof config === "object") {
-    return Object.assign({ parser }, config, { code, filename })
-  }
-  // default
-  return Object.assign({ parser }, { code, filename })
+
+  return Object.assign({ parser }, config, { code, filename })
 }


### PR DESCRIPTION
This PR fixes a false positive in the `svelte/no-unused-svelte-ignore` rule for JS files.
The rule should not check for files other than those parsed by svelte-eslint-parser.

I also changed the test utility so that it can target fixtures other than .svelte.

