### PR TITLE
Add `svelte/no-reactive-literals` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 |:--------|:------------|:---|
 | [svelte/button-has-type](https://ota-meshi.github.io/eslint-plugin-svelte/rules/button-has-type/) | disallow usage of button without an explicit type attribute |  |
 | [svelte/no-at-debug-tags](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-at-debug-tags/) | disallow the use of `{@debug}` | :star: |
+| [svelte/no-reactive-literals](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-reactive-literals/) | Don't assign literal values in reactive statements |  |
 | [svelte/no-unused-svelte-ignore](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore/) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-useless-mustaches/) | disallow unnecessary mustache interpolations | :wrench: |
 | [svelte/require-optimized-style-attribute](https://ota-meshi.github.io/eslint-plugin-svelte/rules/require-optimized-style-attribute/) | require style attributes that can be optimized |  |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -41,6 +41,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 |:--------|:------------|:---|
 | [svelte/button-has-type](./rules/button-has-type.md) | disallow usage of button without an explicit type attribute |  |
 | [svelte/no-at-debug-tags](./rules/no-at-debug-tags.md) | disallow the use of `{@debug}` | :star: |
+| [svelte/no-reactive-literals](./rules/no-reactive-literals.md) | Don't assign literal values in reactive statements |  |
 | [svelte/no-unused-svelte-ignore](./rules/no-unused-svelte-ignore.md) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](./rules/no-useless-mustaches.md) | disallow unnecessary mustache interpolations | :wrench: |
 | [svelte/require-optimized-style-attribute](./rules/require-optimized-style-attribute.md) | require style attributes that can be optimized |  |

--- a/docs/rules/no-reactive-literals.md
+++ b/docs/rules/no-reactive-literals.md
@@ -1,0 +1,32 @@
+#  (svelte/no-reactive-literals)
+
+> Don't assign literal values in reactive statements
+
+## :book: Rule Details
+
+This rule reports on any assignment of a static, unchanging value within a reactive statement because it's not necessary.
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/no-reactive-literals: "error" */
+  /* ✓ GOOD */
+  let foo = "bar";
+  
+  /* ✗ BAD */
+  $: foo = "bar";
+</script>
+```
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+Nothing
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/src/rules/no-reactive-literals.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/tests/src/rules/no-reactive-literals.ts)

--- a/docs/rules/no-reactive-literals.md
+++ b/docs/rules/no-reactive-literals.md
@@ -1,6 +1,15 @@
-#  (svelte/no-reactive-literals)
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "svelte/no-reactive-literals"
+description: "Don't assign literal values in reactive statements"
+---
+
+# svelte/no-reactive-literals
 
 > Don't assign literal values in reactive statements
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
 
 ## :book: Rule Details
 
@@ -20,6 +29,7 @@ This rule reports on any assignment of a static, unchanging value within a react
   $: foo = "bar";
 </script>
 ```
+
 </ESLintCodeBlock>
 
 ## :wrench: Options

--- a/src/rules/no-reactive-literals.ts
+++ b/src/rules/no-reactive-literals.ts
@@ -1,0 +1,69 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import { createRule } from "../utils"
+
+const labeledStatementBase = `SvelteReactiveStatement > ExpressionStatement > AssignmentExpression`
+
+export default createRule("no-reactive-literals", {
+  meta: {
+    docs: {
+      description: "Don't assign literal values in reactive statements",
+      category: "Stylistic Issues",
+      recommended: false,
+      conflictWithPrettier: false,
+    },
+    fixable: "code",
+    schema: [],
+    messages: {
+      noReactiveLiterals: `Do not assign literal values inside reactive statements unless absolutely necessary.`,
+    },
+    type: "suggestion",
+  },
+  create(context) {
+    /**
+     * Reusable method for multiple types of nodes that should warn
+     *
+     * @param node TSESTree.AssignmentExpression the node that was found
+     * @returns void
+     */
+    function warn(node: TSESTree.AssignmentExpression) {
+      // Move upwards to include the entire reactive statement
+      const parent = node.parent?.parent
+
+      if (!parent) {
+        return false
+      }
+
+      const source = context.getSourceCode()
+
+      return context.report({
+        node: parent,
+        loc: parent.loc,
+        messageId: "noReactiveLiterals",
+
+        fix(fixer) {
+          return [
+            // Insert "let" + whatever was in there
+            fixer.insertTextBefore(parent, `let ${source.getText(node)}`),
+
+            // Remove the original reactive statement
+            fixer.remove(parent),
+          ]
+        },
+      })
+    }
+
+    return {
+      // $: foo = "foo";
+      // $: foo = 1;
+      [`${labeledStatementBase}[right.type="Literal"]`]: warn,
+
+      // $: foo = [];
+      [`${labeledStatementBase}[right.type="ArrayExpression"][right.elements.length=0]`]:
+        warn,
+
+      // $: foo = {};
+      [`${labeledStatementBase}[right.type="ObjectExpression"][right.properties.length=0]`]:
+        warn,
+    }
+  },
+})

--- a/src/rules/no-reactive-literals.ts
+++ b/src/rules/no-reactive-literals.ts
@@ -1,69 +1,63 @@
 import type { TSESTree } from "@typescript-eslint/types"
 import { createRule } from "../utils"
 
-const labeledStatementBase = `SvelteReactiveStatement > ExpressionStatement > AssignmentExpression`
-
 export default createRule("no-reactive-literals", {
   meta: {
     docs: {
       description: "Don't assign literal values in reactive statements",
-      category: "Stylistic Issues",
+      category: "Best Practices",
       recommended: false,
-      conflictWithPrettier: false,
     },
-    fixable: "code",
+    hasSuggestions: true,
     schema: [],
     messages: {
       noReactiveLiterals: `Do not assign literal values inside reactive statements unless absolutely necessary.`,
+      fixReactiveLiteral: `Move the literal out of the reactive statement into an assignment`,
     },
     type: "suggestion",
   },
   create(context) {
-    /**
-     * Reusable method for multiple types of nodes that should warn
-     *
-     * @param node TSESTree.AssignmentExpression the node that was found
-     * @returns void
-     */
-    function warn(node: TSESTree.AssignmentExpression) {
-      // Move upwards to include the entire reactive statement
-      const parent = node.parent?.parent
-
-      if (!parent) {
-        return false
-      }
-
-      const source = context.getSourceCode()
-
-      return context.report({
-        node: parent,
-        loc: parent.loc,
-        messageId: "noReactiveLiterals",
-
-        fix(fixer) {
-          return [
-            // Insert "let" + whatever was in there
-            fixer.insertTextBefore(parent, `let ${source.getText(node)}`),
-
-            // Remove the original reactive statement
-            fixer.remove(parent),
-          ]
-        },
-      })
-    }
-
     return {
-      // $: foo = "foo";
-      // $: foo = 1;
-      [`${labeledStatementBase}[right.type="Literal"]`]: warn,
+      [`SvelteReactiveStatement > ExpressionStatement > AssignmentExpression${[
+        // $: foo = "foo";
+        // $: foo = 1;
+        `[right.type="Literal"]`,
 
-      // $: foo = [];
-      [`${labeledStatementBase}[right.type="ArrayExpression"][right.elements.length=0]`]:
-        warn,
+        // $: foo = [];
+        `[right.type="ArrayExpression"][right.elements.length=0]`,
 
-      // $: foo = {};
-      [`${labeledStatementBase}[right.type="ObjectExpression"][right.properties.length=0]`]:
-        warn,
+        // $: foo = {};
+        `[right.type="ObjectExpression"][right.properties.length=0]`,
+      ].join(",")}`](node: TSESTree.AssignmentExpression) {
+        // Move upwards to include the entire reactive statement
+        const parent = node.parent?.parent
+
+        if (!parent) {
+          return false
+        }
+
+        const source = context.getSourceCode()
+
+        return context.report({
+          node: parent,
+          loc: parent.loc,
+          messageId: "noReactiveLiterals",
+          suggest: [
+            {
+              messageId: "fixReactiveLiteral",
+              fix(fixer) {
+                return [
+                  // Insert "let" + whatever was in there
+                  fixer.insertTextBefore(parent, `let ${source.getText(node)}`),
+
+                  // Remove the original reactive statement
+                  fixer.remove(parent),
+                ]
+              },
+            },
+          ],
+        })
+      },
     }
   },
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export interface RuleMetaData {
   }
   messages: { [messageId: string]: string }
   fixable?: "code" | "whitespace"
+  hasSuggestions?: boolean
   schema: JSONSchema4 | JSONSchema4[]
   deprecated?: boolean
   replacedBy?: string[]
@@ -98,6 +99,7 @@ export interface PartialRuleMetaData {
   )
   messages: { [messageId: string]: string }
   fixable?: "code" | "whitespace"
+  hasSuggestions?: boolean
   schema: JSONSchema4 | JSONSchema4[]
   deprecated?: boolean
   replacedBy?: string[]

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -15,6 +15,7 @@ import noDynamicSlotName from "../rules/no-dynamic-slot-name"
 import noInnerDeclarations from "../rules/no-inner-declarations"
 import noNotFunctionHandler from "../rules/no-not-function-handler"
 import noObjectInTextMustaches from "../rules/no-object-in-text-mustaches"
+import noReactiveLiterals from "../rules/no-reactive-literals"
 import noShorthandStylePropertyOverrides from "../rules/no-shorthand-style-property-overrides"
 import noSpacesAroundEqualSignsInAttribute from "../rules/no-spaces-around-equal-signs-in-attribute"
 import noTargetBlank from "../rules/no-target-blank"
@@ -47,6 +48,7 @@ export const rules = [
   noInnerDeclarations,
   noNotFunctionHandler,
   noObjectInTextMustaches,
+  noReactiveLiterals,
   noShorthandStylePropertyOverrides,
   noSpacesAroundEqualSignsInAttribute,
   noTargetBlank,

--- a/tests/fixtures/rules/no-reactive-literals/invalid/test01-errors.json
+++ b/tests/fixtures/rules/no-reactive-literals/invalid/test01-errors.json
@@ -1,0 +1,17 @@
+[
+  {
+    "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
+    "line": 3,
+    "column": 5
+  },
+  {
+    "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
+    "line": 4,
+    "column": 5
+  },
+  {
+    "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
+    "line": 5,
+    "column": 5
+  }
+]

--- a/tests/fixtures/rules/no-reactive-literals/invalid/test01-errors.json
+++ b/tests/fixtures/rules/no-reactive-literals/invalid/test01-errors.json
@@ -2,16 +2,37 @@
   {
     "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
     "line": 3,
-    "column": 5
+    "column": 5,
+    "suggestions": [
+      {
+        "desc": "Move the literal out of the reactive statement into an assignment",
+        "messageId": "fixReactiveLiteral",
+        "output": "<!-- prettier-ignore -->\n<script>\n    let foo = \"foo\"\n    $: bar = [];\n    $: baz = {};\n</script>\n"
+      }
+    ]
   },
   {
     "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
     "line": 4,
-    "column": 5
+    "column": 5,
+    "suggestions": [
+      {
+        "desc": "Move the literal out of the reactive statement into an assignment",
+        "messageId": "fixReactiveLiteral",
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: foo = \"foo\";\n    let bar = []\n    $: baz = {};\n</script>\n"
+      }
+    ]
   },
   {
     "message": "Do not assign literal values inside reactive statements unless absolutely necessary.",
     "line": 5,
-    "column": 5
+    "column": 5,
+    "suggestions": [
+      {
+        "desc": "Move the literal out of the reactive statement into an assignment",
+        "messageId": "fixReactiveLiteral",
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: foo = \"foo\";\n    $: bar = [];\n    let baz = {}\n</script>\n"
+      }
+    ]
   }
 ]

--- a/tests/fixtures/rules/no-reactive-literals/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/invalid/test01-input.svelte
@@ -1,0 +1,6 @@
+<!-- prettier-ignore -->
+<script>
+    $: foo = "foo";
+    $: bar = [];
+    $: baz = {};
+</script>

--- a/tests/fixtures/rules/no-reactive-literals/invalid/test01-output.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/invalid/test01-output.svelte
@@ -1,0 +1,6 @@
+<!-- prettier-ignore -->
+<script>
+    let foo = "foo"
+    let bar = []
+    let baz = {}
+</script>

--- a/tests/fixtures/rules/no-reactive-literals/invalid/test01-output.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/invalid/test01-output.svelte
@@ -1,6 +1,0 @@
-<!-- prettier-ignore -->
-<script>
-    let foo = "foo"
-    let bar = []
-    let baz = {}
-</script>

--- a/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
@@ -1,0 +1,6 @@
+<!-- prettier-ignore -->
+<script>
+    $: foo = "bar" + "baz"
+    $: bar = [ "bar" ]
+    $: baz = { qux : true }
+</script>

--- a/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
@@ -1,6 +1,6 @@
 <!-- prettier-ignore -->
 <script>
-    $: foo = "bar" + "baz"
+    $: foo = `${"bar"}baz`
     $: bar = [ "bar" ]
     $: baz = { qux : true }
 </script>

--- a/tests/src/rules/no-reactive-literals.ts
+++ b/tests/src/rules/no-reactive-literals.ts
@@ -1,0 +1,12 @@
+import { RuleTester } from "eslint"
+import rule from "../../../src/rules/no-reactive-literals"
+import { loadTestCases } from "../../utils/utils"
+
+const tester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+})
+
+tester.run("no-reactive-literals", rule as any, loadTestCases("no-reactive-literals"))

--- a/tests/src/rules/no-reactive-literals.ts
+++ b/tests/src/rules/no-reactive-literals.ts
@@ -3,10 +3,14 @@ import rule from "../../../src/rules/no-reactive-literals"
 import { loadTestCases } from "../../utils/utils"
 
 const tester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 2020,
-        sourceType: "module",
-    },
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
 })
 
-tester.run("no-reactive-literals", rule as any, loadTestCases("no-reactive-literals"))
+tester.run(
+  "no-reactive-literals",
+  rule as any,
+  loadTestCases("no-reactive-literals"),
+)


### PR DESCRIPTION
Porting over another of the simpler rules from https://github.com/tivac/eslint-plugin-svelte/ like we discussed in https://github.com/ota-meshi/eslint-plugin-svelte/issues/198