### PR TITLE
Add `prefer-reactive-destructuring` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 | [svelte/no-reactive-literals](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-reactive-literals/) | Don't assign literal values in reactive statements | :bulb: |
 | [svelte/no-unused-svelte-ignore](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore/) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-useless-mustaches/) | disallow unnecessary mustache interpolations | :wrench: |
+| [svelte/prefer-reactive-destructuring](https://ota-meshi.github.io/eslint-plugin-svelte/rules/prefer-reactive-destructuring/) | Prefer destructuring from objects in reactive statements |  |
 | [svelte/require-optimized-style-attribute](https://ota-meshi.github.io/eslint-plugin-svelte/rules/require-optimized-style-attribute/) | require style attributes that can be optimized |  |
 
 ## Stylistic Issues

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -45,6 +45,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 | [svelte/no-reactive-literals](./rules/no-reactive-literals.md) | Don't assign literal values in reactive statements | :bulb: |
 | [svelte/no-unused-svelte-ignore](./rules/no-unused-svelte-ignore.md) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](./rules/no-useless-mustaches.md) | disallow unnecessary mustache interpolations | :wrench: |
+| [svelte/prefer-reactive-destructuring](./rules/prefer-reactive-destructuring.md) | Prefer destructuring from objects in reactive statements |  |
 | [svelte/require-optimized-style-attribute](./rules/require-optimized-style-attribute.md) | require style attributes that can be optimized |  |
 
 ## Stylistic Issues

--- a/docs/rules/prefer-reactive-destructuring.md
+++ b/docs/rules/prefer-reactive-destructuring.md
@@ -1,0 +1,55 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "svelte/prefer-reactive-destructuring"
+description: "Prefer destructuring from objects in reactive statements"
+---
+
+# svelte/prefer-reactive-destructuring
+
+> Prefer destructuring from objects in reactive statements
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+
+## :book: Rule Details
+
+This rule triggers whenever a reactive statement contains an assignment that could be rewritten using destructuring. This is beneficial because it allows svelte's change-tracking to prevent wasteful redraws whenever the object is changed.
+
+This [svelte REPL](https://svelte.dev/repl/96759f4772314d0a840e11370ef76711) example shows just how effective this can be at preventing bogus redraws.
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/prefer-reactive-destructuring: "error" */
+  /* ✓ GOOD */
+  $: ({ foo } = info)
+  $: ({ bar: baz } = info)
+
+  /* ✗ BAD */
+  $: foo = info.foo
+  $: baz = info.bar
+</script>
+
+
+```
+
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+Nothing
+
+## :heart: Compatibility
+
+This rule was taken from [@tivac/eslint-plugin-svelte].  
+This rule is compatible with `@tivac/svelte/reactive-destructuring` rule.
+
+[@tivac/eslint-plugin-svelte]: https://github.com/tivac/eslint-plugin-svelte/
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/src/rules/prefer-reactive-destructuring.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/tests/src/rules/prefer-reactive-destructuring.ts)

--- a/src/rules/prefer-reactive-destructuring.ts
+++ b/src/rules/prefer-reactive-destructuring.ts
@@ -40,23 +40,27 @@ export default createRule("prefer-reactive-destructuring", {
           node,
           loc: node.loc,
           messageId: "useDestructuring",
-          suggest: [
-            {
-              messageId: "suggestDestructuring",
-              fix: (fixer) => [
-                fixer.insertTextBefore(
-                  lToken,
-                  matched ? `({ ` : `({ ${prop}: `,
-                ),
-                fixer.insertTextAfter(lToken, ` }`),
-                fixer.replaceTextRange(
-                  [rTokens[0].range[0], rTokens[1].range[1]],
-                  "",
-                ),
-                fixer.insertTextAfter(rTokens[1], ")"),
-              ],
-            },
-          ],
+          suggest:
+            // Don't show suggestions for entries like $: info = foo.bar.info, the destructuring
+            // just looks too gross and complicates the rule too much
+            right.object.type === "MemberExpression"
+              ? []
+              : [
+                  {
+                    messageId: "suggestDestructuring",
+                    fix: (fixer) => [
+                      fixer.insertTextBefore(
+                        lToken,
+                        matched ? `({ ` : `({ ${prop}: `,
+                      ),
+                      fixer.insertTextAfter(lToken, ` }`),
+                      fixer.replaceTextRange(
+                        [rTokens[0].range[0], rTokens[1].range[1]],
+                        ")",
+                      ),
+                    ],
+                  },
+                ],
         })
       },
     }

--- a/src/rules/prefer-reactive-destructuring.ts
+++ b/src/rules/prefer-reactive-destructuring.ts
@@ -41,9 +41,8 @@ export default createRule("prefer-reactive-destructuring", {
           loc: node.loc,
           messageId: "useDestructuring",
           suggest:
-            // Don't show suggestions for entries like $: info = foo.bar.info, the destructuring
-            // just looks too gross and complicates the rule too much
-            right.object.type === "MemberExpression"
+            // Don't show suggestions for complex right-hand values, too tricky to get it right
+            right.object.type !== "Identifier" || right.computed
               ? []
               : [
                   {

--- a/src/rules/prefer-reactive-destructuring.ts
+++ b/src/rules/prefer-reactive-destructuring.ts
@@ -1,0 +1,64 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import { createRule } from "../utils"
+
+export default createRule("prefer-reactive-destructuring", {
+  meta: {
+    docs: {
+      description: "Prefer destructuring from objects in reactive statements",
+      category: "Best Practices",
+      recommended: false,
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      useDestructuring: `Prefer destructuring in reactive statements`,
+      suggestDestructuring: `Use destructuring to get finer-grained redraws`,
+    },
+    type: "suggestion",
+  },
+  create(context) {
+    return {
+      // Finds: $: info = foo.info
+      // Suggests:  $: ({ info } = foo);
+      [`SvelteReactiveStatement > ExpressionStatement > AssignmentExpression[left.type="Identifier"][right.type="MemberExpression"]`](
+        node: TSESTree.AssignmentExpression,
+      ) {
+        const left = node.left as TSESTree.Identifier
+        const right = node.right as TSESTree.MemberExpression
+
+        const prop = (right.property as TSESTree.Identifier).name
+
+        const source = context.getSourceCode()
+        const lTokens = source.getTokens(left)
+        const rTokens = source.getTokens(right)
+        const matched = prop === left.name
+
+        return context.report({
+          node,
+          loc: node.loc,
+          messageId: "useDestructuring",
+          suggest: [
+            {
+              messageId: "suggestDestructuring",
+              fix: (fixer) => [
+                fixer.insertTextBefore(
+                  lTokens[0],
+                  matched ? `({ ` : `({ ${prop}: `,
+                ),
+                fixer.insertTextAfter(lTokens[0], ` }`),
+                fixer.replaceTextRange(
+                  [
+                    rTokens[rTokens.length - 2].range[0],
+                    rTokens[rTokens.length - 1].range[1],
+                  ],
+                  "",
+                ),
+                fixer.insertTextAfter(rTokens[rTokens.length - 1], ")"),
+              ],
+            },
+          ],
+        })
+      },
+    }
+  },
+})

--- a/src/rules/prefer-reactive-destructuring.ts
+++ b/src/rules/prefer-reactive-destructuring.ts
@@ -29,8 +29,11 @@ export default createRule("prefer-reactive-destructuring", {
         const prop = (right.property as TSESTree.Identifier).name
 
         const source = context.getSourceCode()
-        const lTokens = source.getTokens(left)
-        const rTokens = source.getTokens(right)
+        const lToken = source.getFirstToken(left)
+        const rTokens = source.getLastTokens(right, {
+          includeComments: true,
+          count: 2,
+        })
         const matched = prop === left.name
 
         return context.report({
@@ -42,18 +45,15 @@ export default createRule("prefer-reactive-destructuring", {
               messageId: "suggestDestructuring",
               fix: (fixer) => [
                 fixer.insertTextBefore(
-                  lTokens[0],
+                  lToken,
                   matched ? `({ ` : `({ ${prop}: `,
                 ),
-                fixer.insertTextAfter(lTokens[0], ` }`),
+                fixer.insertTextAfter(lToken, ` }`),
                 fixer.replaceTextRange(
-                  [
-                    rTokens[rTokens.length - 2].range[0],
-                    rTokens[rTokens.length - 1].range[1],
-                  ],
+                  [rTokens[0].range[0], rTokens[1].range[1]],
                   "",
                 ),
-                fixer.insertTextAfter(rTokens[rTokens.length - 1], ")"),
+                fixer.insertTextAfter(rTokens[1], ")"),
               ],
             },
           ],

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -24,6 +24,7 @@ import noUnknownStyleDirectiveProperty from "../rules/no-unknown-style-directive
 import noUnusedSvelteIgnore from "../rules/no-unused-svelte-ignore"
 import noUselessMustaches from "../rules/no-useless-mustaches"
 import preferClassDirective from "../rules/prefer-class-directive"
+import preferReactiveDestructuring from "../rules/prefer-reactive-destructuring"
 import preferStyleDirective from "../rules/prefer-style-directive"
 import requireOptimizedStyleAttribute from "../rules/require-optimized-style-attribute"
 import shorthandAttribute from "../rules/shorthand-attribute"
@@ -59,6 +60,7 @@ export const rules = [
   noUnusedSvelteIgnore,
   noUselessMustaches,
   preferClassDirective,
+  preferReactiveDestructuring,
   preferStyleDirective,
   requireOptimizedStyleAttribute,
   shorthandAttribute,

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
@@ -1,0 +1,26 @@
+[
+  {
+    "message": "Prefer destructuring in reactive statements",
+    "line": 3,
+    "column": 8,
+    "suggestions": [
+      {
+        "desc": "Use destructuring to get finer-grained redraws",
+        "messageId": "suggestDestructuring",
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: ({ info } = foo)\n    $: bar = foo.something\n</script>\n"
+      }
+    ]
+  },
+  {
+    "message": "Prefer destructuring in reactive statements",
+    "line": 4,
+    "column": 8,
+    "suggestions": [
+      {
+        "desc": "Use destructuring to get finer-grained redraws",
+        "messageId": "suggestDestructuring",
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: info = foo.info\n    $: ({ something: bar } = foo)\n</script>\n"
+      }
+    ]
+  }
+]

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
@@ -7,7 +7,7 @@
       {
         "desc": "Use destructuring to get finer-grained redraws",
         "messageId": "suggestDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n    $: ({ info } = foo)\n    $: bar = foo.something\n</script>\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: ({ info } = foo)\n    $: bar = foo.something\n    $: baz = foo.bar.baz\n</script>\n"
       }
     ]
   },
@@ -19,8 +19,14 @@
       {
         "desc": "Use destructuring to get finer-grained redraws",
         "messageId": "suggestDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n    $: info = foo.info\n    $: ({ something: bar } = foo)\n</script>\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: info = foo.info\n    $: ({ something: bar } = foo)\n    $: baz = foo.bar.baz\n</script>\n"
       }
     ]
+  },
+  {
+    "message": "Prefer destructuring in reactive statements",
+    "line": 5,
+    "column": 8,
+    "suggestions": null
   }
 ]

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-errors.json
@@ -7,7 +7,7 @@
       {
         "desc": "Use destructuring to get finer-grained redraws",
         "messageId": "suggestDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n    $: ({ info } = foo)\n    $: bar = foo.something\n    $: baz = foo.bar.baz\n</script>\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: ({ info } = foo)\n    $: bar = foo.something\n    $: baz = foo.bar.baz\n    $: qux = foo[bar]\n    $: dux = foo.baz().bar\n</script>\n"
       }
     ]
   },
@@ -19,13 +19,25 @@
       {
         "desc": "Use destructuring to get finer-grained redraws",
         "messageId": "suggestDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n    $: info = foo.info\n    $: ({ something: bar } = foo)\n    $: baz = foo.bar.baz\n</script>\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n    $: info = foo.info\n    $: ({ something: bar } = foo)\n    $: baz = foo.bar.baz\n    $: qux = foo[bar]\n    $: dux = foo.baz().bar\n</script>\n"
       }
     ]
   },
   {
     "message": "Prefer destructuring in reactive statements",
     "line": 5,
+    "column": 8,
+    "suggestions": null
+  },
+  {
+    "message": "Prefer destructuring in reactive statements",
+    "line": 6,
+    "column": 8,
+    "suggestions": null
+  },
+  {
+    "message": "Prefer destructuring in reactive statements",
+    "line": 7,
     "column": 8,
     "suggestions": null
   }

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
@@ -1,0 +1,5 @@
+<!-- prettier-ignore -->
+<script>
+    $: info = foo.info
+    $: bar = foo.something
+</script>

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
@@ -2,4 +2,5 @@
 <script>
     $: info = foo.info
     $: bar = foo.something
+    $: baz = foo.bar.baz
 </script>

--- a/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/invalid/test01-input.svelte
@@ -3,4 +3,6 @@
     $: info = foo.info
     $: bar = foo.something
     $: baz = foo.bar.baz
+    $: qux = foo[bar]
+    $: dux = foo.baz().bar
 </script>

--- a/tests/fixtures/rules/prefer-reactive-destructuring/valid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-reactive-destructuring/valid/test01-input.svelte
@@ -1,0 +1,6 @@
+<!-- prettier-ignore -->
+<script>
+    $: ({ info } = foo)
+    $: bar = baz
+    $: qux = `bar ${baz}`
+</script>

--- a/tests/src/rules/prefer-reactive-destructuring.ts
+++ b/tests/src/rules/prefer-reactive-destructuring.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "eslint"
+import rule from "../../../src/rules/prefer-reactive-destructuring"
+import { loadTestCases } from "../../utils/utils"
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "prefer-reactive-destructuring",
+  rule as any,
+  loadTestCases("prefer-reactive-destructuring"),
+)


### PR DESCRIPTION
From the docs:

----

This rule triggers whenever a reactive statement contains an assignment that could be rewritten using destructuring. This is beneficial because it allows svelte's change-tracking to prevent wasteful redraws whenever the object is changed.

This [svelte REPL](https://svelte.dev/repl/96759f4772314d0a840e11370ef76711) example shows just how effective this can be at preventing bogus redraws.

```svelte
<script>
  /* eslint svelte/prefer-reactive-destructuring: "error" */
  /* ✓ GOOD */
  $: ({ foo } = info)
  $: ({ bar: baz } = info)

  /* ✗ BAD */
  $: foo = info.foo
  $: baz = info.bar
</script>
```