### PR TITLE
fix: `no-reactive-literals` using `:matches(...)`

### DIFF
--- a/src/rules/no-reactive-literals.ts
+++ b/src/rules/no-reactive-literals.ts
@@ -18,7 +18,7 @@ export default createRule("no-reactive-literals", {
   },
   create(context) {
     return {
-      [`SvelteReactiveStatement > ExpressionStatement > AssignmentExpression${[
+      [`SvelteReactiveStatement > ExpressionStatement > AssignmentExpression:matches(${[
         // $: foo = "foo";
         // $: foo = 1;
         `[right.type="Literal"]`,
@@ -28,7 +28,7 @@ export default createRule("no-reactive-literals", {
 
         // $: foo = {};
         `[right.type="ObjectExpression"][right.properties.length=0]`,
-      ].join(",")}`](node: TSESTree.AssignmentExpression) {
+      ].join(",")})`](node: TSESTree.AssignmentExpression) {
         // Move upwards to include the entire reactive statement
         const parent = node.parent?.parent
 

--- a/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
+++ b/tests/fixtures/rules/no-reactive-literals/valid/test01-input.svelte
@@ -3,4 +3,10 @@
     $: foo = `${"bar"}baz`
     $: bar = [ "bar" ]
     $: baz = { qux : true }
+
+    let qux;
+    
+    qux = 1;
+    qux = [];
+    qux = {};
 </script>


### PR DESCRIPTION
One of the suggestions on #203 was to use `:matches(...)` around an array `.join()` which somehow got only... halfway implemented. The `.join()` was there, but it was missing the `:matches(...)` around it which could lead to some pretty bad false positives.

Added back the `:matches(...)` and added a few more valid test-cases to watch out for false-positives like this going forward.