### PR TITLE
Add `prefer-destructured-store-props` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
     },
     {
       files: ["*.svelte"],
+      extends: ["plugin:svelte/base"],
       parser: "svelte-eslint-parser",
       parserOptions: {
         parser: {

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 | [svelte/no-reactive-literals](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-reactive-literals/) | Don't assign literal values in reactive statements | :bulb: |
 | [svelte/no-unused-svelte-ignore](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore/) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-useless-mustaches/) | disallow unnecessary mustache interpolations | :wrench: |
+| [svelte/prefer-destructured-store-props](https://ota-meshi.github.io/eslint-plugin-svelte/rules/prefer-destructured-store-props/) | (no description) |  |
 | [svelte/require-optimized-style-attribute](https://ota-meshi.github.io/eslint-plugin-svelte/rules/require-optimized-style-attribute/) | require style attributes that can be optimized |  |
 
 ## Stylistic Issues

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -45,6 +45,7 @@ These rules relate to better ways of doing things to help you avoid problems:
 | [svelte/no-reactive-literals](./rules/no-reactive-literals.md) | Don't assign literal values in reactive statements | :bulb: |
 | [svelte/no-unused-svelte-ignore](./rules/no-unused-svelte-ignore.md) | disallow unused svelte-ignore comments | :star: |
 | [svelte/no-useless-mustaches](./rules/no-useless-mustaches.md) | disallow unnecessary mustache interpolations | :wrench: |
+| [svelte/prefer-destructured-store-props](./rules/prefer-destructured-store-props.md) | (no description) |  |
 | [svelte/require-optimized-style-attribute](./rules/require-optimized-style-attribute.md) | require style attributes that can be optimized |  |
 
 ## Stylistic Issues

--- a/docs/rules/prefer-destructured-store-props.md
+++ b/docs/rules/prefer-destructured-store-props.md
@@ -1,0 +1,53 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "svelte/prefer-destructured-store-props"
+description: "Destructure store props for more efficient redraws"
+---
+
+# svelte/prefer-destructured-store-props
+
+> Destructure store props for more efficient redraws
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+
+## :book: Rule Details
+
+This rule reports on directly accessing properties of a store containing an object. These usages can instead be written as a reactive statement using destructuring to allow for more granular change-tracking and reduced redraws in the component.
+
+An example of the improvements can be see in this [REPL](https://svelte.dev/repl/7de86fea94ff40c48abb82da534dfb89)
+
+<ESLintCodeBlock>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/prefer-destructured-store-props: "error" */
+  $: ({ foo } = $store)
+</script>
+
+<!-- ✓ GOOD -->
+{foo}
+
+<!-- ✗ BAD -->
+{$store.foo}
+```
+
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+Nothing
+
+## :heart: Compatibility
+
+This rule was taken from [@tivac/eslint-plugin-svelte].  
+This rule is compatible with `@tivac/svelte/store-prop-destructuring` rule.
+
+[@tivac/eslint-plugin-svelte]: https://github.com/tivac/eslint-plugin-svelte/
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/src/rules/prefer-destructured-store-props.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/tests/src/rules/prefer-destructured-store-props.ts)

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -1,0 +1,69 @@
+import type { TSESTree } from "@typescript-eslint/types"
+import { createRule } from "../utils"
+
+export default createRule("prefer-destructured-store-props", {
+  meta: {
+    docs: {
+      description: "",
+      category: "Best Practices",
+      recommended: false,
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      useDestructuring: `Destructure {{prop}} from store {{store}} for better change tracking & fewer redraws`,
+      fixUseDestructuring: `Using destructuring like $: ({ {{prop}} } = {{store}}); will run faster`,
+    },
+    type: "suggestion",
+  },
+  create(context) {
+    return {
+      // {$foo.bar + baz}
+      // should be
+      // $: ({ bar } = $foo);
+      // {bar + baz}
+      [`MemberExpression[object.name=/$/][property.type="Identifier"]`](
+        node: TSESTree.MemberExpression,
+      ) {
+        const store = (node.object as TSESTree.Identifier).name
+
+        console.log(node)
+
+        // Since the regex can't specify positioning of the "$", we need to check again
+        if (!store.startsWith("$")) {
+          return false
+        }
+
+        const prop = (node.property as TSESTree.Identifier).name
+
+        return context.report({
+          node,
+          messageId: "useDestructuring",
+          data: {
+            store,
+            prop,
+          },
+          suggest: [
+            {
+              messageId: "fixUseDestructuring",
+              data: {
+                store,
+                prop,
+              },
+
+              fix(fixer) {
+                return [
+                  fixer.insertTextBefore(
+                    node,
+                    `$: ({ ${prop} } = ${store});\n`,
+                  ),
+                  fixer.replaceText(node, prop),
+                ]
+              },
+            },
+          ],
+        })
+      },
+    }
+  },
+})

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -3,7 +3,6 @@ import type { TSESTree } from "@typescript-eslint/types"
 import type { AST } from "svelte-eslint-parser"
 import { createRule } from "../utils"
 import { getStringIfConstant } from "../utils/ast-utils"
-import { returnStatement } from "@babel/types"
 
 type NodeRecord = { property: string; node: TSESTree.MemberExpression }
 
@@ -37,6 +36,16 @@ export default createRule("prefer-destructured-store-props", {
         script = node
       },
 
+      // Capture import names
+      [`ImportSpecifier, ImportDefaultSpecifier, ImportNamespaceSpecifier`](
+        node: TSESTree.ImportSpecifier,
+      ) {
+        const { name } = node.local
+
+        defined.add(name)
+      },
+
+      // Capture variable names
       [`VariableDeclarator[id.type="Identifier"]`](
         node: TSESTree.VariableDeclarator,
       ) {

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -22,16 +22,10 @@ export default createRule("prefer-destructured-store-props", {
       // should be
       // $: ({ bar } = $foo);
       // {bar + baz}
-      [`MemberExpression[object.name=/$/][property.type="Identifier"]`](
+      [`MemberExpression[object.name=/^\\$/][property.type="Identifier"]`](
         node: TSESTree.MemberExpression,
       ) {
         const store = (node.object as TSESTree.Identifier).name
-
-        // Since the regex can't specify positioning of the "$", we need to check again
-        if (!store.startsWith("$")) {
-          return false
-        }
-
         const prop = (node.property as TSESTree.Identifier).name
 
         return context.report({

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -1,10 +1,12 @@
 import type { TSESTree } from "@typescript-eslint/types"
+import type { AST } from "svelte-eslint-parser"
 import { createRule } from "../utils"
 
 export default createRule("prefer-destructured-store-props", {
   meta: {
     docs: {
-      description: "",
+      description:
+        "Destructure values from object stores for better change tracking & fewer redraws",
       category: "Best Practices",
       recommended: false,
     },
@@ -17,7 +19,14 @@ export default createRule("prefer-destructured-store-props", {
     type: "suggestion",
   },
   create(context) {
+    let script: AST.SvelteScriptElement
+    const reports: TSESTree.MemberExpression[] = []
+
     return {
+      [`SvelteScriptElement`](node: AST.SvelteScriptElement) {
+        script = node
+      },
+
       // {$foo.bar + baz}
       // should be
       // $: ({ bar } = $foo);
@@ -25,35 +34,45 @@ export default createRule("prefer-destructured-store-props", {
       [`MemberExpression[object.name=/^\\$/][property.type="Identifier"]`](
         node: TSESTree.MemberExpression,
       ) {
-        const store = (node.object as TSESTree.Identifier).name
-        const prop = (node.property as TSESTree.Identifier).name
+        reports.push(node)
+      },
 
-        return context.report({
-          node,
-          messageId: "useDestructuring",
-          data: {
-            store,
-            prop,
-          },
-          suggest: [
-            {
-              messageId: "fixUseDestructuring",
-              data: {
-                store,
-                prop,
-              },
+      [`Program:exit`]() {
+        reports.forEach((node) => {
+          const store = (node.object as TSESTree.Identifier).name
+          const prop = (node.property as TSESTree.Identifier).name
 
-              fix(fixer) {
-                return [
-                  fixer.insertTextBefore(
-                    node,
-                    `$: ({ ${prop} } = ${store});\n`,
-                  ),
-                  fixer.replaceText(node, prop),
-                ]
-              },
+          context.report({
+            node,
+            messageId: "useDestructuring",
+            data: {
+              store,
+              prop,
             },
-          ],
+            suggest: [
+              {
+                messageId: "fixUseDestructuring",
+                data: {
+                  store,
+                  prop,
+                },
+
+                fix(fixer) {
+                  if (!script || !script.endTag) {
+                    return []
+                  }
+
+                  return [
+                    fixer.insertTextAfterRange(
+                      [script.endTag.range[0], script.endTag.range[0]],
+                      `$: ({ ${prop} } = ${store});\n`,
+                    ),
+                    fixer.replaceText(node, prop),
+                  ]
+                },
+              },
+            ],
+          })
         })
       },
     }

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -3,6 +3,7 @@ import type { TSESTree } from "@typescript-eslint/types"
 import type { AST } from "svelte-eslint-parser"
 import { createRule } from "../utils"
 import { getStringIfConstant } from "../utils/ast-utils"
+import { returnStatement } from "@babel/types"
 
 type NodeRecord = { property: string; node: TSESTree.MemberExpression }
 
@@ -17,18 +18,31 @@ export default createRule("prefer-destructured-store-props", {
     hasSuggestions: true,
     schema: [],
     messages: {
-      useDestructuring: `Destructure {{property}} from store {{store}} for better change tracking & fewer redraws`,
+      useDestructuring: `Destructure {{property}} from {{store}} for better change tracking & fewer redraws`,
       fixUseDestructuring: `Using destructuring like $: ({ {{property}} } = {{store}}); will run faster`,
     },
     type: "suggestion",
   },
   create(context) {
     let script: AST.SvelteScriptElement
+
+    // Store off instances of probably-destructurable statements
     const reports: NodeRecord[] = []
+
+    // Store off defined variable names so we can avoid offering a suggestion in those cases
+    const defined: Set<string> = new Set()
 
     return {
       [`SvelteScriptElement`](node: AST.SvelteScriptElement) {
         script = node
+      },
+
+      [`VariableDeclarator[id.type="Identifier"]`](
+        node: TSESTree.VariableDeclarator,
+      ) {
+        const { name } = node.id as TSESTree.Identifier
+
+        defined.add(name)
       },
 
       // {$foo.bar}
@@ -54,13 +68,6 @@ export default createRule("prefer-destructured-store-props", {
       [`Program:exit`]() {
         reports.forEach(({ property, node }) => {
           const store = (node.object as TSESTree.Identifier).name
-          // let prop: string | null = null
-
-          // if (node.property.type === "Literal") {
-          //   prop = node.property.value as string
-          // } else if (node.property.type === "Identifier") {
-          //   prop = node.property.name
-          // }
 
           context.report({
             node,
@@ -70,33 +77,42 @@ export default createRule("prefer-destructured-store-props", {
               property,
             },
 
-            suggest: [
-              {
-                messageId: "fixUseDestructuring",
-                data: {
-                  store,
-                  property,
-                },
+            // Avoid suggestions for:
+            //  dynamic accesses like {$foo[bar]}
+            //  no <script> tag
+            //  no <script> ending
+            //  variable name already defined
+            suggest:
+              node.computed ||
+              !script ||
+              !script.endTag ||
+              defined.has(property)
+                ? []
+                : [
+                    {
+                      messageId: "fixUseDestructuring",
+                      data: {
+                        store,
+                        property,
+                      },
 
-                fix(fixer) {
-                  // Avoid autofix suggestions for:
-                  //  dynamic accesses like {$foo[bar]}
-                  //  no <script> tag
-                  //  no <script> ending
-                  if (node.computed || !script || !script.endTag) {
-                    return []
-                  }
+                      fix(fixer) {
+                        // This is only necessary to make TS shut up about script.endTag maybe being null
+                        // but since we already checked it above that warning is just wrong
+                        if (!script.endTag) {
+                          return []
+                        }
 
-                  return [
-                    fixer.insertTextAfterRange(
-                      [script.endTag.range[0], script.endTag.range[0]],
-                      `$: ({ ${property} } = ${store});\n`,
-                    ),
-                    fixer.replaceText(node, property),
-                  ]
-                },
-              },
-            ],
+                        return [
+                          fixer.insertTextAfterRange(
+                            [script.endTag.range[0], script.endTag.range[0]],
+                            `$: ({ ${property} } = ${store});\n`,
+                          ),
+                          fixer.replaceText(node, property),
+                        ]
+                      },
+                    },
+                  ],
           })
         })
       },

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -27,8 +27,6 @@ export default createRule("prefer-destructured-store-props", {
       ) {
         const store = (node.object as TSESTree.Identifier).name
 
-        console.log(node)
-
         // Since the regex can't specify positioning of the "$", we need to check again
         if (!store.startsWith("$")) {
           return false

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -24,6 +24,7 @@ import noUnknownStyleDirectiveProperty from "../rules/no-unknown-style-directive
 import noUnusedSvelteIgnore from "../rules/no-unused-svelte-ignore"
 import noUselessMustaches from "../rules/no-useless-mustaches"
 import preferClassDirective from "../rules/prefer-class-directive"
+import preferDestructuredStoreProps from "../rules/prefer-destructured-store-props"
 import preferStyleDirective from "../rules/prefer-style-directive"
 import requireOptimizedStyleAttribute from "../rules/require-optimized-style-attribute"
 import shorthandAttribute from "../rules/shorthand-attribute"
@@ -59,6 +60,7 @@ export const rules = [
   noUnusedSvelteIgnore,
   noUselessMustaches,
   preferClassDirective,
+  preferDestructuredStoreProps,
   preferStyleDirective,
   requireOptimizedStyleAttribute,
   shorthandAttribute,

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
@@ -7,32 +7,20 @@
       {
         "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
         "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{bar}\n\n{$foo[baz]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo[\"qux\"]}\n"
       }
     ]
   },
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 7,
+    "message": "Destructure baz from store $foo for better change tracking & fewer redraws",
+    "line": 8,
     "column": 2,
-    "suggestions": [
-      {
-        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
-        "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{$foo.bar}\n{bar}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
-      }
-    ]
+    "suggestions": null
   },
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 10,
+    "message": "Destructure qux from store $foo for better change tracking & fewer redraws",
+    "line": 11,
     "column": 2,
-    "suggestions": [
-      {
-        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
-        "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{$foo.bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{bar}\n"
-      }
-    ]
+    "suggestions": null
   }
 ]

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
@@ -1,37 +1,37 @@
 [
   {
     "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 2,
-    "column": 2,
-    "suggestions": [
-      {
-        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
-        "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n{$: ({ bar } = $foo);\nbar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
-      }
-    ]
-  },
-  {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 3,
-    "column": 2,
-    "suggestions": [
-      {
-        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
-        "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$: ({ bar } = $foo);\nbar}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
-      }
-    ]
-  },
-  {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
     "line": 6,
     "column": 2,
     "suggestions": [
       {
         "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
         "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$: ({ bar } = $foo);\nbar}\n"
+        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
+      }
+    ]
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 7,
+    "column": 2,
+    "suggestions": [
+      {
+        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
+        "messageId": "fixUseDestructuring",
+        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{$foo.bar}\n{bar}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
+      }
+    ]
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 10,
+    "column": 2,
+    "suggestions": [
+      {
+        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
+        "messageId": "fixUseDestructuring",
+        "output": "<!-- prettier-ignore -->\n<script>\n\n$: ({ bar } = $foo);\n</script>\n\n{$foo.bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{bar}\n"
       }
     ]
   }

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
@@ -1,0 +1,26 @@
+[
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 2,
+    "column": 2,
+    "suggestions": [
+      {
+        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
+        "messageId": "fixUseDestructuring",
+        "output": "<!-- prettier-ignore -->\n{$: ({ bar } = $foo);\nbar}\n{$foo[bar]}\n{$foo[\"bar\"]}\n"
+      }
+    ]
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 3,
+    "column": 2,
+    "suggestions": [
+      {
+        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
+        "messageId": "fixUseDestructuring",
+        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$: ({ bar } = $foo);\nbar}\n{$foo[\"bar\"]}\n"
+      }
+    ]
+  }
+]

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
@@ -7,7 +7,7 @@
       {
         "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
         "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n{$: ({ bar } = $foo);\nbar}\n{$foo[bar]}\n{$foo[\"bar\"]}\n"
+        "output": "<!-- prettier-ignore -->\n{$: ({ bar } = $foo);\nbar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
       }
     ]
   },
@@ -19,7 +19,19 @@
       {
         "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
         "messageId": "fixUseDestructuring",
-        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$: ({ bar } = $foo);\nbar}\n{$foo[\"bar\"]}\n"
+        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$: ({ bar } = $foo);\nbar}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$foo.bar}\n"
+      }
+    ]
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 6,
+    "column": 2,
+    "suggestions": [
+      {
+        "desc": "Using destructuring like $: ({ bar } = $foo); will run faster",
+        "messageId": "fixUseDestructuring",
+        "output": "<!-- prettier-ignore -->\n{$foo.bar}\n{$foo[bar]}\n\n<!-- eslint-disable-next-line dot-notation -- tests -->\n{$: ({ bar } = $foo);\nbar}\n"
       }
     ]
   }

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-errors.json
@@ -1,6 +1,6 @@
 [
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure bar from $foo for better change tracking & fewer redraws",
     "line": 6,
     "column": 2,
     "suggestions": [
@@ -12,13 +12,13 @@
     ]
   },
   {
-    "message": "Destructure baz from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure baz from $foo for better change tracking & fewer redraws",
     "line": 8,
     "column": 2,
     "suggestions": null
   },
   {
-    "message": "Destructure qux from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure qux from $foo for better change tracking & fewer redraws",
     "line": 11,
     "column": 2,
     "suggestions": null

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
@@ -1,0 +1,4 @@
+<!-- prettier-ignore -->
+{$foo.bar}
+{$foo[bar]}
+{$foo["bar"]}

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
@@ -4,7 +4,8 @@
 </script>
 
 {$foo.bar}
-{$foo[bar]}
+
+{$foo[baz]}
 
 <!-- eslint-disable-next-line dot-notation -- tests -->
-{$foo.bar}
+{$foo["qux"]}

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test01-input.svelte
@@ -1,4 +1,6 @@
 <!-- prettier-ignore -->
 {$foo.bar}
 {$foo[bar]}
-{$foo["bar"]}
+
+<!-- eslint-disable-next-line dot-notation -- tests -->
+{$foo.bar}

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
@@ -1,18 +1,18 @@
 [
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure bar from $foo for better change tracking & fewer redraws",
     "line": 2,
     "column": 2,
     "suggestions": null
   },
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure bar from $foo for better change tracking & fewer redraws",
     "line": 4,
     "column": 2,
     "suggestions": null
   },
   {
-    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "message": "Destructure bar from $foo for better change tracking & fewer redraws",
     "line": 7,
     "column": 2,
     "suggestions": null

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
@@ -1,0 +1,20 @@
+[
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 2,
+    "column": 2,
+    "suggestions": null
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 3,
+    "column": 2,
+    "suggestions": null
+  },
+  {
+    "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
+    "line": 6,
+    "column": 2,
+    "suggestions": null
+  }
+]

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-errors.json
@@ -7,13 +7,13 @@
   },
   {
     "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 3,
+    "line": 4,
     "column": 2,
     "suggestions": null
   },
   {
     "message": "Destructure bar from store $foo for better change tracking & fewer redraws",
-    "line": 6,
+    "line": 7,
     "column": 2,
     "suggestions": null
   }

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-input.svelte
@@ -1,8 +1,4 @@
 <!-- prettier-ignore -->
-<script>
-
-</script>
-
 {$foo.bar}
 {$foo[bar]}
 

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test02-input.svelte
@@ -1,6 +1,7 @@
 <!-- prettier-ignore -->
 {$foo.bar}
+
 {$foo[bar]}
 
 <!-- eslint-disable-next-line dot-notation -- tests -->
-{$foo.bar}
+{$foo["bar"]}

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
@@ -1,0 +1,14 @@
+[
+  {
+    "message": "Destructure foo from $store for better change tracking & fewer redraws",
+    "line": 7,
+    "column": 11,
+    "suggestions": null
+  },
+  {
+    "message": "Destructure bar from $store for better change tracking & fewer redraws",
+    "line": 8,
+    "column": 11,
+    "suggestions": null
+  }
+]

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
@@ -13,7 +13,7 @@
   },
   {
     "message": "Destructure baz from $store for better change tracking & fewer redraws",
-    "line": 20,
+    "line": 22,
     "column": 9,
     "suggestions": null
   }

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-errors.json
@@ -1,14 +1,20 @@
 [
   {
     "message": "Destructure foo from $store for better change tracking & fewer redraws",
-    "line": 7,
+    "line": 8,
     "column": 11,
     "suggestions": null
   },
   {
     "message": "Destructure bar from $store for better change tracking & fewer redraws",
-    "line": 8,
+    "line": 9,
     "column": 11,
+    "suggestions": null
+  },
+  {
+    "message": "Destructure baz from $store for better change tracking & fewer redraws",
+    "line": 20,
+    "column": 9,
     "suggestions": null
   }
 ]

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
@@ -11,9 +11,11 @@
 </script>
 
 <div>
+  <!-- eslint-disable-next-line prefer-template-->
   foo: {foo + " " + Date.now()}
 </div>
 <div>
+  <!-- eslint-disable-next-line prefer-template-->
   bar: {bar + " " + Date.now()}
 </div>
 <div>

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
@@ -1,6 +1,7 @@
 <!-- prettier-ignore -->
 <script>
   import store from "./store.js";
+  import baz from "somewhere"
 	
   let foo, bar
   $: {
@@ -14,4 +15,7 @@
 </div>
 <div>
   bar: {bar + " " + Date.now()}
+</div>
+<div>
+  baz: {$store.baz}
 </div>

--- a/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/invalid/test03-input.svelte
@@ -1,0 +1,17 @@
+<!-- prettier-ignore -->
+<script>
+  import store from "./store.js";
+	
+  let foo, bar
+  $: {
+    foo = $store.foo;
+    bar = $store.bar;
+  }
+</script>
+
+<div>
+  foo: {foo + " " + Date.now()}
+</div>
+<div>
+  bar: {bar + " " + Date.now()}
+</div>

--- a/tests/fixtures/rules/prefer-destructured-store-props/valid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/valid/test01-input.svelte
@@ -1,0 +1,3 @@
+<!-- prettier-ignore -->
+{$foo[`bar${baz}`]}
+{foo$.bar}

--- a/tests/fixtures/rules/prefer-destructured-store-props/valid/test01-input.svelte
+++ b/tests/fixtures/rules/prefer-destructured-store-props/valid/test01-input.svelte
@@ -1,3 +1,4 @@
 <!-- prettier-ignore -->
 {$foo[`bar${baz}`]}
 {foo$.bar}
+{f$oo.bar}

--- a/tests/src/rules/prefer-destructured-store-props.ts
+++ b/tests/src/rules/prefer-destructured-store-props.ts
@@ -1,0 +1,16 @@
+import { RuleTester } from "eslint"
+import rule from "../../../src/rules/prefer-destructured-store-props"
+import { loadTestCases } from "../../utils/utils"
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+})
+
+tester.run(
+  "prefer-destructured-store-props",
+  rule as any,
+  loadTestCases("prefer-destructured-store-props"),
+)


### PR DESCRIPTION
## :book: Rule Details

This rule reports on directly accessing properties of a store containing an object. These usages can instead be written as a reactive statement using destructuring to allow for more granular change-tracking and reduced redraws in the component.

An example of the improvements can be see in this [REPL](https://svelte.dev/repl/7de86fea94ff40c48abb82da534dfb89)

```svelte
<script>
  /* eslint svelte/prefer-destructured-store-props: "error" */
  $: ({ foo } = $store)
</script>

<!-- ✓ GOOD -->
{foo}

<!-- ✗ BAD -->
{$store.foo}
```