### PR TITLE
Chore: Fix `docs:watch` to work on Windows

### DIFF
--- a/docs-svelte-kit/build-system/build.mts
+++ b/docs-svelte-kit/build-system/build.mts
@@ -5,9 +5,8 @@ import { fileURLToPath } from "url"
 // const babelCore = require("@babel/core")
 // const t = require("@babel/types")
 
-const dirname = fileURLToPath(
-  new URL(
-    ".",
+const dirname = path.dirname(
+  fileURLToPath(
     // @ts-expect-error -- Cannot change `module` option
     import.meta.url,
   ),

--- a/docs-svelte-kit/build-system/build.mts
+++ b/docs-svelte-kit/build-system/build.mts
@@ -33,14 +33,13 @@ function build(input: string, out: string, injects: string[] = []) {
 
 /** bundle */
 function bundle(entryPoint: string, externals: string[]) {
-  const injectPath = path.join(dirname, "./src/process-shim.mjs")
   const result = esbuild.buildSync({
     entryPoints: [entryPoint],
     format: "esm",
     bundle: true,
     external: externals,
     write: false,
-    inject: [injectPath],
+    inject: [path.join(dirname, "./src/process-shim.mjs")],
   })
 
   return `${result.outputFiles[0].text}`

--- a/docs-svelte-kit/build-system/build.mts
+++ b/docs-svelte-kit/build-system/build.mts
@@ -1,14 +1,16 @@
 import esbuild from "esbuild"
 import path from "path"
 import fs from "fs"
+import { fileURLToPath } from "url"
 // const babelCore = require("@babel/core")
 // const t = require("@babel/types")
 
-const dirname = path.dirname(
+const dirname = fileURLToPath(
   new URL(
+    ".",
     // @ts-expect-error -- Cannot change `module` option
     import.meta.url,
-  ).pathname,
+  ),
 )
 
 build(
@@ -32,13 +34,14 @@ function build(input: string, out: string, injects: string[] = []) {
 
 /** bundle */
 function bundle(entryPoint: string, externals: string[]) {
+  const injectPath = path.join(dirname, "./src/process-shim.mjs")
   const result = esbuild.buildSync({
     entryPoints: [entryPoint],
     format: "esm",
     bundle: true,
     external: externals,
     write: false,
-    inject: [path.join(dirname, "./src/process-shim.mjs")],
+    inject: [injectPath],
   })
 
   return `${result.outputFiles[0].text}`

--- a/svelte.config.mjs
+++ b/svelte.config.mjs
@@ -8,7 +8,7 @@ if (typeof self === "undefined") {
   globalThis.self = globalThis
 }
 
-const dirname = fileURLToPath(new URL(".", import.meta.url))
+const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // This project can't be ESM yet, so hack it to get svelte-kit to work.
 // A hack that treats files in the `.svelte-kit` directory as ESM.

--- a/svelte.config.mjs
+++ b/svelte.config.mjs
@@ -1,13 +1,14 @@
 import ghpagesAdapter from "svelte-adapter-ghpages"
 import path from "path"
 import fs from "fs"
+import { fileURLToPath } from "url"
 
 // eslint-disable-next-line no-undef -- There seems to be a package that uses `self`.
 if (typeof self === "undefined") {
   globalThis.self = globalThis
 }
 
-const dirname = path.dirname(new URL(import.meta.url).pathname)
+const dirname = fileURLToPath(new URL(".", import.meta.url))
 
 // This project can't be ESM yet, so hack it to get svelte-kit to work.
 // A hack that treats files in the `.svelte-kit` directory as ESM.

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -8,9 +8,8 @@ import "./docs-svelte-kit/build-system/build.mts"
 import type { UserConfig } from "vite"
 import { fileURLToPath } from "url"
 
-const dirname = fileURLToPath(
-  new URL(
-    ".",
+const dirname = path.dirname(
+  fileURLToPath(
     // @ts-expect-error -- Cannot change `module` option
     import.meta.url,
   ),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,12 +6,14 @@ import svelteMdOption from "./docs-svelte-kit/tools/vite-plugin-svelte-md-option
 
 import "./docs-svelte-kit/build-system/build.mts"
 import type { UserConfig } from "vite"
+import { fileURLToPath } from "url"
 
-const dirname = path.dirname(
+const dirname = fileURLToPath(
   new URL(
+    ".",
     // @ts-expect-error -- Cannot change `module` option
     import.meta.url,
-  ).pathname,
+  ),
 )
 
 /** @type {import('vite').UserConfig} */


### PR DESCRIPTION
This PR fixes `docs:watch` to work on Windows.

It seems I didn't understand how to use `import.meta.url` properly.