### PR TITLE
docs: uncapitalized first letters in rule desceiptions

### DIFF
--- a/src/rules/no-reactive-functions.ts
+++ b/src/rules/no-reactive-functions.ts
@@ -6,7 +6,7 @@ export default createRule("no-reactive-functions", {
   meta: {
     docs: {
       description:
-        "It's not necessary to define functions in reactive statements",
+        "it's not necessary to define functions in reactive statements",
       category: "Best Practices",
       recommended: false,
     },

--- a/src/rules/no-reactive-literals.ts
+++ b/src/rules/no-reactive-literals.ts
@@ -4,7 +4,7 @@ import { createRule } from "../utils"
 export default createRule("no-reactive-literals", {
   meta: {
     docs: {
-      description: "Don't assign literal values in reactive statements",
+      description: "don't assign literal values in reactive statements",
       category: "Best Practices",
       recommended: false,
     },


### PR DESCRIPTION
see https://github.com/ota-meshi/eslint-plugin-svelte/pull/186#discussion_r926289266

Rules added by @tivac have first letters in desceiption capitalized, which is inconsistent with the rest of the plugin.

![Screenshot_20220811-211655_Firefox](https://user-images.githubusercontent.com/73162071/184221372-01514bb9-763b-4c3b-b75a-9185acf98489.png)

This is also the case in #205 and #208.