### PR TITLE
chore: change changesets config

### DIFF
--- a/.env-cmdrc
+++ b/.env-cmdrc
@@ -2,6 +2,9 @@
   "version": {
     "IN_VERSION_SCRIPT": "true"
   },
+  "version-ci": {
+    "IN_VERSION_CI_SCRIPT": "true"
+  },
   "debug": {
     "DEBUG": "eslint-plugin-svelte*"
   }

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: yarn version
+          version: yarn version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release
           commit: "chore: release eslint-plugin-svelte"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 .svelte-kit
 .type-coverage
 build
-lib
+/lib

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ts": "node -r esbuild-register",
     "typecov": "type-coverage",
     "update": "yarn ts ./tools/update.ts && yarn format-for-gen-file",
-    "version": "env-cmd -e version yarn update && changeset version"
+    "version": "env-cmd -e version yarn update",
+    "version:ci": "env-cmd -e version-ci yarn update && changeset version"
   },
   "peerDependencies": {
     "eslint": "^7.0.0 || ^8.0.0-0",
@@ -169,7 +170,7 @@
     "access": "public"
   },
   "typeCoverage": {
-    "atLeast": 98.63,
+    "atLeast": 98.64,
     "cache": true,
     "detail": true,
     "ignoreAsAssertion": true,

--- a/tools/lib/changesets-util.ts
+++ b/tools/lib/changesets-util.ts
@@ -1,0 +1,27 @@
+import assembleReleasePlan from "@changesets/assemble-release-plan"
+import readChangesets from "@changesets/read"
+import { read } from "@changesets/config"
+import { getPackages } from "@manypkg/get-packages"
+import { readPreState } from "@changesets/pre"
+import path from "path"
+
+const root = path.resolve(__dirname, "../..")
+
+/** Get new version string from changesets */
+export async function getNewVersion(): Promise<string> {
+  const packages = await getPackages(root)
+  const preState = await readPreState(root)
+  const config = await read(root, packages)
+  const changesets = await readChangesets(root)
+
+  const releasePlan = assembleReleasePlan(
+    changesets,
+    packages,
+    config,
+    preState,
+  )
+
+  return releasePlan.releases.find(
+    ({ name }) => name === "eslint-plugin-svelte",
+  )!.newVersion
+}

--- a/tools/update-docs.ts
+++ b/tools/update-docs.ts
@@ -2,6 +2,7 @@ import path from "path"
 import fs from "fs"
 import { rules } from "../src/utils/rules"
 import type { RuleModule } from "../src/types"
+import { getNewVersion } from "./lib/changesets-util"
 
 //eslint-disable-next-line require-jsdoc -- tools
 function formatItems(items: string[]) {
@@ -24,7 +25,7 @@ function yamlValue(val: unknown) {
 const ROOT = path.resolve(__dirname, "../docs/rules")
 
 //eslint-disable-next-line require-jsdoc -- tools
-function pickSince(content: string): string | null {
+function pickSince(content: string): string | null | Promise<string> {
   const fileIntro = /^---\n((?:.*\n)+)---\n*/.exec(content)
   if (fileIntro) {
     const since = /since: "?(v\d+\.\d+\.\d+)"?/.exec(fileIntro[1])
@@ -37,6 +38,10 @@ function pickSince(content: string): string | null {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- ignore
     return `v${require("../package.json").version}`
   }
+  // eslint-disable-next-line no-process-env -- ignore
+  if (process.env.IN_VERSION_CI_SCRIPT) {
+    return getNewVersion().then((v) => `v${v}`)
+  }
   return null
 }
 
@@ -47,7 +52,7 @@ class DocFile {
 
   private content: string
 
-  private readonly since: string | null
+  private readonly since: string | null | Promise<string>
 
   public constructor(rule: RuleModule) {
     this.rule = rule
@@ -135,7 +140,7 @@ class DocFile {
     return this
   }
 
-  public updateFooter() {
+  public async updateFooter() {
     const { ruleName, extensionRule } = this.rule.meta.docs
     const footerPattern =
       /## (?:(?::mag:)? ?Implementation|:rocket: Version).+$/s
@@ -143,7 +148,7 @@ class DocFile {
       this.since
         ? `## :rocket: Version
 
-This rule was introduced in eslint-plugin-svelte ${this.since}
+This rule was introduced in eslint-plugin-svelte ${await this.since}
 
 `
         : ""
@@ -203,7 +208,7 @@ ${
     return this
   }
 
-  public updateFileIntro() {
+  public async updateFileIntro() {
     const { ruleId, description } = this.rule.meta.docs
 
     const fileIntro = {
@@ -211,7 +216,7 @@ ${
       sidebarDepth: 0,
       title: ruleId,
       description,
-      ...(this.since ? { since: this.since } : {}),
+      ...(this.since ? { since: await this.since } : {}),
     }
     const computed = `---\n${Object.keys(fileIntro)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- tool
@@ -239,12 +244,17 @@ ${
   }
 }
 
-for (const rule of rules) {
-  DocFile.read(rule)
-    .updateHeader()
-    .updateFooter()
-    .updateCodeBlocks()
-    .updateFileIntro()
-    .adjustCodeBlocks()
-    .write()
+void main()
+
+/** main */
+async function main() {
+  for (const rule of rules) {
+    const doc = DocFile.read(rule)
+    doc.updateHeader()
+    await doc.updateFooter()
+    doc.updateCodeBlocks()
+    await doc.updateFileIntro()
+    doc.adjustCodeBlocks()
+    doc.write()
+  }
 }


### PR DESCRIPTION
The `yarn version` script from Actions cannot determine the version, and it seems to end without changing, so change the script.