### PR TITLE
fix: remove no-store-async rule from recommended config

### DIFF
--- a/src/rules/no-store-async.ts
+++ b/src/rules/no-store-async.ts
@@ -7,7 +7,9 @@ export default createRule("no-store-async", {
       description:
         "disallow using async/await inside svelte stores because it causes issues with the auto-unsubscribing features",
       category: "Possible Errors",
-      recommended: true,
+      // TODO Switch to recommended in the major version.
+      // recommended: true,
+      recommended: false,
       default: "error",
     },
     schema: [],


### PR DESCRIPTION
This PR removes the no-store-async rule from the recommended configuration.
It should have been done in a major version upgrade as it is included in breaking changes.