### PR TITLE
test: ignore indent test for decorators with ts4.8

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "yarn --ignore-engines",
+  "installCommand": "install --ignore-engines",
   "node": "16",
   "sandboxes": []
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "install --ignore-engines",
+  "installCommand": "install-with-ignore-engines",
   "node": "16",
   "sandboxes": []
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "yarn --ignore-engines",
   "node": "16",
   "sandboxes": []
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "docs:preview": "yarn svelte-kit preview",
     "docs:watch": "yarn svelte-kit dev",
     "format-for-gen-file": "eslint src/types-for-node.ts src/utils/rules.ts src/configs --fix",
+    "install-with-ignore-engines": "yarn --ignore-engines",
     "lint": "run-p lint:*",
     "lint-fix": "yarn lint:es --fix && yarn lint:style --fix",
     "lint:es": "eslint --cache -f friendly .",

--- a/tests/src/rules/indent.ts
+++ b/tests/src/rules/indent.ts
@@ -33,6 +33,15 @@ describe("use @typescript-eslint/parser@4", () => {
     rule as any,
     loadTestCases("indent", {
       filter(filename) {
+        if (
+          filename.endsWith("ts-class03-input.svelte") ||
+          filename.endsWith("ts-decorator01-input.svelte") ||
+          filename.endsWith("ts-decorator02-input.svelte")
+        ) {
+          // Decorator nodes in ts4.8 are incompatible.
+          return false
+        }
+
         return path.basename(path.dirname(filename)) === "ts"
       },
     }),


### PR DESCRIPTION
It seems there was a breaking change in decorator nodes in ts4.8. Because of this some tests using typescript-eslint v4 fail so ignoring these tests.

---

It also fixes yarn install in codesandbox-ci failing because svelte kit no longer supports Node v16.13.