### PR TITLE
chore: use vite v3.1-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "svelte-adapter-ghpages": "0.0.2",
     "type-coverage": "^2.22.0",
     "typescript": "^4.5.2",
-    "vite": "^3.0.0-0",
+    "vite": "^3.1.0-0",
     "vite-plugin-svelte-md": "^0.1.5",
     "yaml": "^2.1.1",
     "yarn-deduplicate": "^6.0.0"


### PR DESCRIPTION
vite 3.1-beta is now required for the latest svelte kit to work.

https://github.com/sveltejs/kit/pull/6398