### PR TITLE
feat: add `svelte/@typescript-eslint/no-unnecessary-condition` rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,6 +11,7 @@
 /tests/fixtures/rules/valid-compile/valid/babel
 /tests/fixtures/rules/valid-compile/valid/ts
 /tests/fixtures/rules/prefer-style-directive
+/tests/fixtures/rules/@typescript-eslint
 /.svelte-kit
 /svelte.config-dist.js
 /build

--- a/.eslintignore
+++ b/.eslintignore
@@ -11,7 +11,6 @@
 /tests/fixtures/rules/valid-compile/valid/babel
 /tests/fixtures/rules/valid-compile/valid/ts
 /tests/fixtures/rules/prefer-style-directive
-/tests/fixtures/rules/@typescript-eslint
 /.svelte-kit
 /svelte.config-dist.js
 /build

--- a/README.md
+++ b/README.md
@@ -322,10 +322,11 @@ These rules relate to style guidelines, and are therefore quite subjective:
 
 ## Extension Rules
 
-These rules extend the rules provided by ESLint itself to work well in Svelte:
+These rules extend the rules provided by ESLint itself, or other plugins to work well in Svelte:
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [svelte/@typescript-eslint/no-unnecessary-condition](https://ota-meshi.github.io/eslint-plugin-svelte/rules/@typescript-eslint/no-unnecessary-condition/) | disallow conditionals where the type is always truthy or always falsy | :wrench: |
 | [svelte/no-inner-declarations](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-inner-declarations/) | disallow variable or `function` declarations in nested blocks | :star: |
 | [svelte/no-trailing-spaces](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-trailing-spaces/) | disallow trailing whitespace at the end of lines | :wrench: |
 

--- a/docs-svelte-kit/src/lib/components/ESLintPlayground.svelte
+++ b/docs-svelte-kit/src/lib/components/ESLintPlayground.svelte
@@ -9,11 +9,12 @@
     preprocess,
     postprocess,
   } from "../eslint/scripts/linter.js"
+  import { loadTsParser } from "../eslint/scripts/ts-parser.js"
   import { loadModulesForBrowser } from "../../../../src/shared/svelte-compile-warns/transform/load-module"
   let tsParser = null
   const linter = loadModulesForBrowser()
     .then(async () => {
-      tsParser = await import("@typescript-eslint/parser")
+      tsParser = await loadTsParser()
     })
     .then(() => {
       return createLinter()

--- a/docs-svelte-kit/src/lib/eslint/ESLintEditor.svelte
+++ b/docs-svelte-kit/src/lib/eslint/ESLintEditor.svelte
@@ -35,6 +35,8 @@
     lint(linter, code, config, options)
   })
 
+  let lastResult = {}
+
   async function lint(linter, code, config, options) {
     messageMap.clear()
     /* eslint-disable no-param-reassign -- ignore */
@@ -69,12 +71,23 @@
       fixedMessages: fixResult.messages,
     })
 
-    leftMarkers = await Promise.all(
+    lastResult = { messages, fixResult }
+
+    const markers = await Promise.all(
       messages.map((m) => messageToMarker(m, messageMap)),
     )
-    rightMarkers = await Promise.all(
+    const fixedMarkers = await Promise.all(
       fixResult.messages.map((m) => messageToMarker(m)),
     )
+    if (
+      lastResult.messages !== messages ||
+      lastResult.fixResult !== fixResult
+    ) {
+      // If the result has changed, don't update the markers
+      return
+    }
+    leftMarkers = markers
+    rightMarkers = fixedMarkers
   }
 
   function applyFix() {

--- a/docs-svelte-kit/src/lib/eslint/scripts/monaco-loader.js
+++ b/docs-svelte-kit/src/lib/eslint/scripts/monaco-loader.js
@@ -45,17 +45,23 @@ function appendMonacoEditorScript() {
 let setupedMonaco = null
 let editorLoaded = null
 
-export async function loadMonacoEditor() {
-  await (setupedMonaco || (setupedMonaco = setupMonaco()))
+export function loadMonacoEngine() {
+  return setupedMonaco || (setupedMonaco = setupMonaco())
+}
+export function loadMonacoEditor() {
   return (
     editorLoaded ||
-    (editorLoaded = new Promise((resolve) => {
-      if (typeof window !== "undefined") {
-        // eslint-disable-next-line node/no-missing-require -- ignore
-        window.require(["vs/editor/editor.main"], (r) => {
-          resolve(r)
-        })
-      }
-    }))
+    (editorLoaded = loadModuleFromMonaco("vs/editor/editor.main"))
   )
+}
+
+export async function loadModuleFromMonaco(moduleName) {
+  await loadMonacoEngine()
+  return new Promise((resolve) => {
+    if (typeof window !== "undefined") {
+      window.require([moduleName], (r) => {
+        resolve(r)
+      })
+    }
+  })
 }

--- a/docs-svelte-kit/src/lib/eslint/scripts/ts-create-program.mts
+++ b/docs-svelte-kit/src/lib/eslint/scripts/ts-create-program.mts
@@ -1,0 +1,101 @@
+import type typescript from "typescript"
+import type tsvfs from "@typescript/vfs"
+type TS = typeof typescript
+type TSVFS = typeof tsvfs
+
+/** Create Program */
+export function createProgram(
+  {
+    ts,
+    compilerOptions,
+    compilerHost,
+  }: {
+    ts: TS
+    compilerOptions: typescript.CompilerOptions
+    compilerHost: typescript.CompilerHost
+  },
+  options: { filePath: string },
+): typescript.Program {
+  try {
+    const program = ts.createProgram({
+      rootNames: [options.filePath],
+      options: compilerOptions,
+      host: compilerHost,
+    })
+    return program
+  } catch (e) {
+    // eslint-disable-next-line no-console -- Demo debug
+    console.error(e)
+    throw e
+  }
+}
+
+export function createCompilerOptions(ts: TS): typescript.CompilerOptions {
+  const compilerOptions: typescript.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    strict: true,
+  }
+  compilerOptions.lib = [ts.getDefaultLibFileName(compilerOptions)]
+  return compilerOptions
+}
+
+export async function createVirtualCompilerHost(
+  {
+    ts,
+    tsvfs,
+    compilerOptions,
+  }: {
+    ts: TS
+    tsvfs: TSVFS
+    compilerOptions: typescript.CompilerOptions
+  },
+  { filePath: targetFilePath }: { filePath: string },
+): Promise<{
+  compilerHost: typescript.CompilerHost
+  updateFile: (sourceFile: typescript.SourceFile) => boolean
+  fsMap: Map<string, string>
+}> {
+  const fsMap = await tsvfs.createDefaultMapFromCDN(
+    {
+      lib: Array.from(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- use internal
+        (ts as any).libMap.keys(),
+      ),
+    },
+    ts.version,
+    true,
+    ts,
+  )
+  const system = tsvfs.createSystem(fsMap)
+  const host = tsvfs.createVirtualCompilerHost(system, compilerOptions, ts)
+  // eslint-disable-next-line @typescript-eslint/unbound-method -- backup original
+  const original = { getSourceFile: host.compilerHost.getSourceFile }
+  host.compilerHost.getSourceFile = function (
+    fileName,
+    languageVersionOrOptions,
+    ...args
+  ) {
+    if (targetFilePath === fileName) {
+      // Exclude the target file from caching as it will be modified.
+      const file = this.readFile(fileName) ?? ""
+      return ts.createSourceFile(fileName, file, languageVersionOrOptions, true)
+    }
+    if (this.fileExists(fileName)) {
+      return original.getSourceFile.apply(this, [
+        fileName,
+        languageVersionOrOptions,
+        ...args,
+      ])
+    }
+    // Avoid error
+    // eslint-disable-next-line no-console -- Demo debug
+    console.log(`Not exists: ${fileName}`)
+    return undefined
+  }
+  return {
+    ...host,
+    fsMap,
+  }
+}

--- a/docs-svelte-kit/src/lib/eslint/scripts/ts-parser.js
+++ b/docs-svelte-kit/src/lib/eslint/scripts/ts-parser.js
@@ -1,0 +1,54 @@
+import { loadMonacoEngine } from "./monaco-loader"
+import {
+  createProgram,
+  createCompilerOptions,
+  createVirtualCompilerHost,
+} from "./ts-create-program.mts"
+
+let tsParserCache = null
+export function loadTsParser() {
+  return (tsParserCache ??= loadTsParserImpl())
+}
+
+async function loadTsParserImpl() {
+  await loadMonacoEngine()
+  const [ts, tsvfs, tsParser] = await Promise.all([
+    import("typescript"),
+    import("@typescript/vfs"),
+    import("@typescript-eslint/parser"),
+  ])
+  if (typeof window === "undefined") {
+    return tsParser
+  }
+  window.define("typescript", ts)
+
+  const compilerOptions = createCompilerOptions(ts)
+  const filePath = "/demo.ts"
+  const host = await createVirtualCompilerHost(
+    { ts, tsvfs, compilerOptions },
+    { filePath },
+  )
+  return {
+    parseForESLint(code, options) {
+      host.fsMap.set(filePath, code)
+      // Requires its own Program instance to provide full type information.
+      const program = createProgram(
+        { ts, compilerHost: host.compilerHost, compilerOptions },
+        { filePath },
+      )
+
+      try {
+        const result = tsParser.parseForESLint(code, {
+          ...options,
+          filePath: filePath.replace(/^\//u, ""),
+          programs: [program],
+        })
+        return result
+      } catch (e) {
+        // eslint-disable-next-line no-console -- Demo debug
+        console.error(e)
+        throw e
+      }
+    },
+  }
+}

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -75,10 +75,11 @@ These rules relate to style guidelines, and are therefore quite subjective:
 
 ## Extension Rules
 
-These rules extend the rules provided by ESLint itself to work well in Svelte:
+These rules extend the rules provided by ESLint itself, or other plugins to work well in Svelte:
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [svelte/@typescript-eslint/no-unnecessary-condition](./rules/@typescript-eslint/no-unnecessary-condition.md) | disallow conditionals where the type is always truthy or always falsy | :wrench: |
 | [svelte/no-inner-declarations](./rules/no-inner-declarations.md) | disallow variable or `function` declarations in nested blocks | :star: |
 | [svelte/no-trailing-spaces](./rules/no-trailing-spaces.md) | disallow trailing whitespace at the end of lines | :wrench: |
 

--- a/docs/rules/@typescript-eslint/no-unnecessary-condition.md
+++ b/docs/rules/@typescript-eslint/no-unnecessary-condition.md
@@ -14,21 +14,25 @@ description: "disallow conditionals where the type is always truthy or always fa
 
 ## :book: Rule Details
 
-This rule reports ???.
+This rule extends the base `@typescript-eslint`'s [@typescript-eslint/no-unnecessary-condition] rule.
+The [@typescript-eslint/no-unnecessary-condition] rule does not understand reactive or rerendering of Svelte components and has false positives when used with Svelte components. This rule understands reactive and rerendering of Svelte components.
 
 <ESLintCodeBlock fix>
 
 <!--eslint-skip-->
 
 ```svelte
-<script>
+<script lang="ts">
   /* eslint svelte/@typescript-eslint/no-unnecessary-condition: "error" */
+  export let foo: number | null = null
+  /* ✗ BAD */
+  let b = foo || 42
+  /* ✓ GOOD */
+  $: a = foo || 42
 </script>
 
 <!-- ✓ GOOD -->
-
-<!-- ✗ BAD -->
-
+{foo || 42}
 ```
 
 </ESLintCodeBlock>
@@ -37,17 +41,24 @@ This rule reports ???.
 
 ```json
 {
-  "svelte/@typescript-eslint/no-unnecessary-condition": ["error", {
-   
-  }]
+  "@typescript-eslint/no-unnecessary-condition": "off",
+  "svelte/@typescript-eslint/no-unnecessary-condition": [
+    "error",
+    {
+      "allowConstantLoopConditions": false,
+      "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": false
+    }
+  ]
 }
 ```
 
-- 
+Same as [@typescript-eslint/no-unnecessary-condition] rule option. See [here](https://typescript-eslint.io/rules/no-unnecessary-condition/#options) for details.
 
-## :books: Further Reading
+## :couple: Related rules
 
--
+- [@typescript-eslint/no-unnecessary-condition]
+
+[@typescript-eslint/no-unnecessary-condition]: https://typescript-eslint.io/rules/no-unnecessary-condition/
 
 ## :mag: Implementation
 

--- a/docs/rules/@typescript-eslint/no-unnecessary-condition.md
+++ b/docs/rules/@typescript-eslint/no-unnecessary-condition.md
@@ -1,0 +1,57 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "svelte/@typescript-eslint/no-unnecessary-condition"
+description: "disallow conditionals where the type is always truthy or always falsy"
+---
+
+# svelte/@typescript-eslint/no-unnecessary-condition
+
+> disallow conditionals where the type is always truthy or always falsy
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule reports ???.
+
+<ESLintCodeBlock fix>
+
+<!--eslint-skip-->
+
+```svelte
+<script>
+  /* eslint svelte/@typescript-eslint/no-unnecessary-condition: "error" */
+</script>
+
+<!-- ✓ GOOD -->
+
+<!-- ✗ BAD -->
+
+```
+
+</ESLintCodeBlock>
+
+## :wrench: Options
+
+```json
+{
+  "svelte/@typescript-eslint/no-unnecessary-condition": ["error", {
+   
+  }]
+}
+```
+
+- 
+
+## :books: Further Reading
+
+-
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/tests/src/rules/@typescript-eslint/no-unnecessary-condition.ts)
+
+<sup>Taken with ❤️ [from @typescript-eslint/eslint-plugin](https://typescript-eslint.io/rules/no-unnecessary-condition/)</sup>

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.1-0",
     "@typescript-eslint/parser-v4": "npm:@typescript-eslint/parser@4",
+    "@typescript/vfs": "^1.4.0",
     "assert": "^2.0.0",
     "commitlint": "^17.0.3",
     "env-cmd": "^10.1.0",

--- a/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -1,0 +1,788 @@
+// This rule is based on typescript-eslint's no-unnecessary-condition rule
+// and modified to work well with Svelte components.
+// https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+import type { TSESTree } from "@typescript-eslint/types"
+import type { AST } from "svelte-eslint-parser"
+import type * as ESTree from "estree"
+import { createRule } from "../../utils"
+import {
+  isFalsyType,
+  getConstrainedTypeAtLocation,
+  isTruthyLiteral,
+  isPossiblyFalsyType,
+  isNullishType,
+  isBooleanLiteralType,
+  getTypeScriptTools,
+  isAnyType,
+  isUnknownType,
+  isNeverType,
+  getCallSignaturesOfType,
+  isNullableType,
+  getTypeOfPropertyOfType,
+  getTypeName,
+  isTupleType,
+} from "../../utils/ts-utils"
+import type { TS, TSTools } from "../../utils/ts-utils"
+
+/**
+ * Returns all types of a union type or an array containing `type` itself if it's no union type.
+ * This method is heavily inspired by tsutils. https://github.com/ajafff/tsutils
+ * The MIT License (MIT) Copyright (c) 2017 Klaus Meinhardt
+ * https://github.com/ajafff/tsutils/blob/master/LICENSE
+ */
+function unionTypeParts(type: TS.Type): TS.Type[] {
+  return [...iterate(type)]
+
+  /**
+   * iterate
+   */
+  function* iterate(t: TS.Type): Iterable<TS.Type> {
+    if (t.isUnion()) {
+      for (const type of t.types) {
+        yield* iterate(type)
+      }
+    } else {
+      yield t
+    }
+  }
+}
+
+/**
+ * Check whether the given type can be a falsy type or not.
+ */
+function isPossiblyFalsy(type: TS.Type, tsTools: TSTools): boolean {
+  return (
+    unionTypeParts(type)
+      // PossiblyFalsy flag includes literal values, so exclude ones that
+      // are definitely truthy
+      .filter((t) => !isTruthyLiteral(t, tsTools))
+      .some((type) => isPossiblyFalsyType(type, tsTools.ts))
+  )
+}
+
+/**
+ * Check whether the given type can be a truthy type or not.
+ */
+function isPossiblyTruthy(type: TS.Type, tsTools: TSTools): boolean {
+  return unionTypeParts(type).some((type) => !isFalsyType(type, tsTools))
+}
+
+/**
+ * Check whether the given type can be a nullish type or not.
+ */
+function isPossiblyNullish(type: TS.Type, tsTools: TSTools): boolean {
+  return isNullableType(type, tsTools.ts)
+}
+
+/**
+ * Check whether the given type is a nullish type or not.
+ */
+function isAlwaysNullish(type: TS.Type, tsTools: TSTools): boolean {
+  return isNullishType(type, tsTools.ts)
+}
+
+/**
+ * Check whether the given type is a literal type or not.
+ */
+function isLiteral(type: TS.Type, tsTools: TSTools): boolean {
+  return (
+    isBooleanLiteralType(type, tsTools.ts) ||
+    isNullishType(type, tsTools.ts) ||
+    type.isLiteral()
+  )
+}
+
+export default createRule("@typescript-eslint/no-unnecessary-condition", {
+  meta: {
+    docs: {
+      description:
+        "disallow conditionals where the type is always truthy or always falsy",
+      category: "Extension Rules",
+      recommended: false,
+      extensionRule: {
+        plugin: "@typescript-eslint/eslint-plugin",
+        url: "https://typescript-eslint.io/rules/no-unnecessary-condition/",
+      },
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowConstantLoopConditions: {
+            description:
+              "Whether to ignore constant loop conditions, such as `while (true)`.",
+            type: "boolean",
+          },
+          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
+            description:
+              "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    fixable: "code",
+    messages: {
+      alwaysTruthy: "Unnecessary conditional, value is always truthy.",
+      alwaysFalsy: "Unnecessary conditional, value is always falsy.",
+      alwaysTruthyFunc:
+        "This callback should return a conditional, but return is always truthy.",
+      alwaysFalsyFunc:
+        "This callback should return a conditional, but return is always falsy.",
+      neverNullish:
+        "Unnecessary conditional, expected left-hand side of `??` operator to be possibly null or undefined.",
+      alwaysNullish:
+        "Unnecessary conditional, left-hand side of `??` operator is always `null` or `undefined`.",
+      literalBooleanExpression:
+        "Unnecessary conditional, both sides of the expression are literal values.",
+      noOverlapBooleanExpression:
+        "Unnecessary conditional, the types have no overlap.",
+      never: "Unnecessary conditional, value is `never`.",
+      neverOptionalChain: "Unnecessary optional chain on a non-nullish value.",
+      noStrictNullCheck:
+        "This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.",
+    },
+    type: "suggestion", // "problem", or "layout",
+  },
+  create(context) {
+    const {
+      allowConstantLoopConditions = false,
+      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = false,
+    } = (context.options[0] || {}) as {
+      allowConstantLoopConditions?: boolean
+      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean
+    }
+    const tools = getTypeScriptTools(context)
+    if (!tools) {
+      return {}
+    }
+
+    const { service, ts } = tools
+    const checker = service.program.getTypeChecker()
+    const sourceCode = context.getSourceCode()
+    const compilerOptions = service.program.getCompilerOptions()
+    const isStrictNullChecks = compilerOptions.strict
+      ? compilerOptions.strictNullChecks !== false
+      : compilerOptions.strictNullChecks
+
+    if (
+      !isStrictNullChecks &&
+      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing !== true
+    ) {
+      context.report({
+        loc: {
+          start: { line: 0, column: 0 },
+          end: { line: 0, column: 0 },
+        },
+        messageId: "noStrictNullCheck",
+      })
+    }
+
+    const mutableVarReferenceIds: ESTree.Identifier[] = []
+    const scriptElements: AST.SvelteScriptElement[] = []
+    let inSvelteReactiveStatement = false
+
+    // Extract references to mutable variables in the root scope.
+    for (const scope of [
+      sourceCode.scopeManager.globalScope,
+      sourceCode.scopeManager.globalScope?.childScopes.find(
+        (scope) => scope.type === "module",
+      ),
+    ]) {
+      if (!scope) continue
+      for (const variable of scope.variables) {
+        if (
+          variable.defs.some(
+            (def) =>
+              def.type === "Variable" &&
+              (def.parent.kind === "var" || def.parent.kind === "let"),
+          )
+        ) {
+          for (const reference of variable.references) {
+            mutableVarReferenceIds.push(reference.identifier)
+          }
+        }
+      }
+    }
+
+    // Extract <script> ranges.
+    for (const body of sourceCode.ast.body) {
+      if (body.type === "SvelteScriptElement") {
+        scriptElements.push(body)
+      }
+    }
+
+    /**
+     * Checks whether the given expression node is in Svelte reactive scope
+     * and the variables that make up the given expression node use
+     * mutable variables declared in component root scope.
+     */
+    function hasSvelteReactiveVar(
+      node: TSESTree.Expression | TSESTree.SpreadElement,
+    ): boolean {
+      const inReactiveScope =
+        inSvelteReactiveStatement ||
+        (scriptElements.length &&
+          scriptElements.every(
+            (elem) =>
+              node.range[1] <= elem.range[0] || elem.range[1] <= node.range[0],
+          ))
+      if (!inReactiveScope) {
+        // The given expression node is neither in a reactive scope nor in a template scope.
+        return false
+      }
+
+      return mutableVarReferenceIds.some(
+        (id) => node.range[0] <= id.range![0] && id.range![1] <= node.range[1],
+      )
+    }
+
+    /** Get the TS type from ES Node */
+    function getNodeType(
+      node:
+        | TSESTree.Expression
+        | TSESTree.PrivateIdentifier
+        | TSESTree.SpreadElement,
+    ): TS.Type | undefined {
+      const tsNode = service.esTreeNodeToTSNodeMap.get(node)
+      return tsNode && getConstrainedTypeAtLocation(checker, tsNode)
+    }
+
+    /**
+     * Check whether the given node is an array type or not.
+     */
+    function nodeIsArrayType(node: TSESTree.Expression): boolean {
+      const nodeType = getNodeType(node)
+      if (!nodeType) {
+        return false
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- isArrayType is an internal API of TS.
+      return (checker as any).isArrayType(nodeType)
+    }
+
+    /**
+     * Check whether the given node is an tuple type or not.
+     */
+    function nodeIsTupleType(node: TSESTree.Expression): boolean {
+      const nodeType = getNodeType(node)
+      return Boolean(nodeType && isTupleType(nodeType, ts))
+    }
+
+    /**
+     * Check whether the given node is an array index signature or not.
+     */
+    function isArrayIndexExpression(node: TSESTree.Expression): boolean {
+      return (
+        // Is an index signature
+        node.type === "MemberExpression" &&
+        node.computed &&
+        // ...into an array type
+        (nodeIsArrayType(node.object) ||
+          // ... or a tuple type
+          (nodeIsTupleType(node.object) &&
+            // Exception: literal index into a tuple - will have a sound type
+            node.property.type !== "Literal"))
+      )
+    }
+
+    /**
+     * Checks if a conditional node is necessary:
+     * if the type of the node is always true or always false, it's not necessary.
+     */
+    function checkNode(
+      node: TSESTree.Expression,
+      isUnaryNotArgument = false,
+    ): void {
+      if (hasSvelteReactiveVar(node)) {
+        return
+      }
+
+      // Check if the node is Unary Negation expression and handle it
+      if (node.type === "UnaryExpression" && node.operator === "!") {
+        checkNode(node.argument, true)
+        return
+      }
+
+      // Since typescript array index signature types don't represent the
+      //  possibility of out-of-bounds access, if we're indexing into an array
+      //  just skip the check, to avoid false positives
+      //
+      // Unless the node is nullish coalescing, as it's common to use patterns like `nullBool ?? true` to to strict
+      //  boolean checks if we inspect the right here, it'll usually be a constant condition on purpose.
+      // In this case it's better to inspect the type of the expression as a whole.
+      if (node.type === "LogicalExpression" && node.operator !== "??") {
+        checkNode(node.right)
+        return
+      }
+
+      const type = getNodeType(node)
+
+      // Conditional is always necessary if it involves:
+      //    `any` or `unknown` or a naked type parameter
+      if (
+        !type ||
+        unionTypeParts(type).some(
+          (part) =>
+            isAnyType(part, ts) ||
+            isUnknownType(part, ts) ||
+            part.isTypeParameter(),
+        )
+      ) {
+        return
+      }
+      let messageId: string | null = null
+
+      if (unionTypeParts(type).some((part) => isNeverType(part, ts))) {
+        messageId = "never"
+      } else if (!isPossiblyTruthy(type, tools!)) {
+        messageId = !isUnaryNotArgument ? "alwaysFalsy" : "alwaysTruthy"
+      } else if (!isPossiblyFalsy(type, tools!)) {
+        messageId = !isUnaryNotArgument ? "alwaysTruthy" : "alwaysFalsy"
+      }
+
+      if (messageId) {
+        context.report({ node, messageId })
+      }
+    }
+
+    /**
+     * Checks if a conditional node is necessary from the given lhs of nullish coalescing.
+     */
+    function checkNodeForNullish(node: TSESTree.Expression): void {
+      if (hasSvelteReactiveVar(node)) {
+        return
+      }
+
+      const type = getNodeType(node)
+      // Conditional is always necessary if it involves `any` or `unknown`
+      if (!type || isAnyType(type, ts) || isUnknownType(type, ts)) {
+        return
+      }
+
+      let messageId: string | null = null
+      if (unionTypeParts(type).some((part) => isNeverType(part, ts))) {
+        messageId = "never"
+      } else if (!isPossiblyNullish(type, tools!)) {
+        // Since typescript array index signature types don't represent the
+        //  possibility of out-of-bounds access, if we're indexing into an array
+        //  just skip the check, to avoid false positives
+        if (
+          !isArrayIndexExpression(node) &&
+          !(
+            node.type === "ChainExpression" &&
+            node.expression.type !== "TSNonNullExpression" &&
+            optionChainContainsOptionArrayIndex(node.expression)
+          )
+        ) {
+          messageId = "neverNullish"
+        }
+      } else if (isAlwaysNullish(type, tools!)) {
+        messageId = "alwaysNullish"
+      }
+
+      if (messageId) {
+        context.report({ node, messageId })
+      }
+    }
+
+    /**
+     * Checks that a binary expression is necessarily conditional, reports otherwise.
+     * If both sides of the binary expression are literal values, it's not a necessary condition.
+     *
+     * NOTE: It's also unnecessary if the types that don't overlap at all
+     *    but that case is handled by the Typescript compiler itself.
+     *    Known exceptions:
+     *      * https://github.com/microsoft/TypeScript/issues/32627
+     *      * https://github.com/microsoft/TypeScript/issues/37160 (handled)
+     */
+    const BOOL_OPERATORS = new Set([
+      "<",
+      ">",
+      "<=",
+      ">=",
+      "==",
+      "===",
+      "!=",
+      "!==",
+    ])
+
+    /**
+     * Checks if a conditional node is necessary from the given binary expression.
+     */
+    function checkIfBinaryExpressionIsNecessaryConditional(
+      node: TSESTree.BinaryExpression,
+    ): void {
+      if (hasSvelteReactiveVar(node)) {
+        return
+      }
+
+      if (!BOOL_OPERATORS.has(node.operator)) {
+        return
+      }
+      const leftType = getNodeType(node.left)
+      const rightType = getNodeType(node.right)
+      if (!leftType || !rightType) {
+        return
+      }
+      if (isLiteral(leftType, tools!) && isLiteral(rightType, tools!)) {
+        context.report({ node, messageId: "literalBooleanExpression" })
+        return
+      }
+      // Workaround for https://github.com/microsoft/TypeScript/issues/37160
+      if (isStrictNullChecks) {
+        const UNDEFINED = ts.TypeFlags.Undefined
+        const NULL = ts.TypeFlags.Null
+        // eslint-disable-next-line func-style -- ignore
+        const isComparable = (type: TS.Type, f: TS.TypeFlags): boolean => {
+          let flag = f
+          // Allow comparison to `any`, `unknown` or a naked type parameter.
+          flag |=
+            ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter
+
+          // Allow loose comparison to nullish values.
+          if (node.operator === "==" || node.operator === "!=") {
+            flag |= NULL | UNDEFINED
+          }
+
+          return unionTypeParts(type).some((t) => (t.flags & flag) !== 0)
+        }
+
+        if (
+          (leftType.flags === UNDEFINED &&
+            !isComparable(rightType, UNDEFINED)) ||
+          (rightType.flags === UNDEFINED &&
+            !isComparable(leftType, UNDEFINED)) ||
+          (leftType.flags === NULL && !isComparable(rightType, NULL)) ||
+          (rightType.flags === NULL && !isComparable(leftType, NULL))
+        ) {
+          context.report({ node, messageId: "noOverlapBooleanExpression" })
+        }
+      }
+    }
+
+    /**
+     * Checks that a logical expression contains a boolean, reports otherwise.
+     */
+    function checkLogicalExpressionForUnnecessaryConditionals(
+      node: TSESTree.LogicalExpression,
+    ): void {
+      if (node.operator === "??") {
+        checkNodeForNullish(node.left)
+        return
+      }
+      // Only checks the left side, since the right side might not be "conditional" at all.
+      // The right side will be checked if the LogicalExpression is used in a conditional context
+      checkNode(node.left)
+    }
+
+    /**
+     * Checks that a testable expression of a loop is necessarily conditional, reports otherwise.
+     */
+    function checkIfLoopIsNecessaryConditional(
+      node:
+        | TSESTree.DoWhileStatement
+        | TSESTree.ForStatement
+        | TSESTree.WhileStatement,
+    ): void {
+      if (node.test === null) {
+        // e.g. `for(;;)`
+        return
+      }
+
+      /**
+       * Allow:
+       *   while (true) {}
+       *   for (;true;) {}
+       *   do {} while (true)
+       */
+      if (allowConstantLoopConditions) {
+        const nodeType = getNodeType(node.test)
+        if (
+          nodeType &&
+          isBooleanLiteralType(nodeType, ts) &&
+          checker.typeToString(nodeType) === "true"
+        )
+          return
+      }
+
+      checkNode(node.test)
+    }
+
+    const ARRAY_PREDICATE_FUNCTIONS = new Set([
+      "filter",
+      "find",
+      "some",
+      "every",
+    ])
+
+    /**
+     * Checks whether the given call expression is an array method that takes a predicate as an argument.
+     */
+    function isArrayPredicateFunction(node: TSESTree.CallExpression): boolean {
+      const { callee } = node
+      return (
+        // looks like `something.filter` or `something.find`
+        callee.type === "MemberExpression" &&
+        callee.property.type === "Identifier" &&
+        ARRAY_PREDICATE_FUNCTIONS.has(callee.property.name) &&
+        // and the left-hand side is an array, according to the types
+        (nodeIsArrayType(callee.object) || nodeIsTupleType(callee.object))
+      )
+    }
+
+    /**
+     * Checks if a conditional node is necessary from the given call expression.
+     */
+    function checkCallExpression(node: TSESTree.CallExpression): void {
+      // If this is something like arr.filter(x => /*condition*/), check `condition`
+      if (isArrayPredicateFunction(node) && node.arguments.length) {
+        const callback = node.arguments[0]
+        // Inline defined functions
+        if (
+          (callback.type === "ArrowFunctionExpression" ||
+            callback.type === "FunctionExpression") &&
+          callback.body
+        ) {
+          // Two special cases, where we can directly check the node that's returned:
+          // () => something
+          if (callback.body.type !== "BlockStatement") {
+            checkNode(callback.body)
+            return
+          }
+          // () => { return something; }
+          const callbackBody = callback.body.body
+          if (
+            callbackBody.length === 1 &&
+            callbackBody[0].type === "ReturnStatement" &&
+            callbackBody[0].argument
+          ) {
+            checkNode(callbackBody[0].argument)
+            return
+          }
+          // Potential enhancement: could use code-path analysis to check
+          //   any function with a single return statement
+          // (Value to complexity ratio is dubious however)
+        }
+        const nodeType = getNodeType(callback)
+        if (!nodeType) {
+          return
+        }
+        // Otherwise just do type analysis on the function as a whole.
+        const returnTypes = getCallSignaturesOfType(nodeType).map((sig) =>
+          sig.getReturnType(),
+        )
+        /* istanbul ignore if */ if (returnTypes.length === 0) {
+          // Not a callable function
+          return
+        }
+        // Predicate is always necessary if it involves `any` or `unknown`
+        if (returnTypes.some((t) => isAnyType(t, ts) || isUnknownType(t, ts))) {
+          return
+        }
+        if (!returnTypes.some((t) => isPossiblyFalsy(t, tools!))) {
+          context.report({
+            node: callback,
+            messageId: "alwaysTruthyFunc",
+          })
+          return
+        }
+        if (!returnTypes.some((t) => isPossiblyTruthy(t, tools!))) {
+          context.report({
+            node: callback,
+            messageId: "alwaysFalsyFunc",
+          })
+        }
+      }
+    }
+
+    /**
+     *
+     * Recursively searches an optional chain for an array index expression
+     *  Has to search the entire chain, because an array index will "infect" the rest of the types
+     *  Example:
+     *  ```
+     *  [{x: {y: "z"} }][n] // type is {x: {y: "z"}}
+     *    ?.x // type is {y: "z"}
+     *    ?.y // This access is considered "unnecessary" according to the types
+     *  ```
+     */
+    function optionChainContainsOptionArrayIndex(
+      node: TSESTree.MemberExpression | TSESTree.CallExpression,
+    ): boolean {
+      const lhsNode = node.type === "CallExpression" ? node.callee : node.object
+      if (node.optional && isArrayIndexExpression(lhsNode)) {
+        return true
+      }
+      if (
+        lhsNode.type === "MemberExpression" ||
+        lhsNode.type === "CallExpression"
+      ) {
+        return optionChainContainsOptionArrayIndex(lhsNode)
+      }
+      return false
+    }
+
+    /**
+     * Check whether the given property is a nullable or not.
+     */
+    function isNullablePropertyType(
+      objType: TS.Type,
+      propertyType: TS.Type,
+    ): boolean {
+      if (propertyType.isUnion()) {
+        return propertyType.types.some((type) =>
+          isNullablePropertyType(objType, type),
+        )
+      }
+      if (propertyType.isNumberLiteral() || propertyType.isStringLiteral()) {
+        const propType = getTypeOfPropertyOfType(
+          objType,
+          propertyType.value.toString(),
+          checker,
+        )
+        if (propType) {
+          return isNullableType(propType, ts)
+        }
+      }
+      const typeName = getTypeName(propertyType, tools!)
+      return Boolean(
+        (typeName === "string" &&
+          checker.getIndexInfoOfType(objType, ts.IndexKind.String)) ||
+          (typeName === "number" &&
+            checker.getIndexInfoOfType(objType, ts.IndexKind.Number)),
+      )
+    }
+
+    /**
+     * Checks whether a member expression is nullable or not regardless of it's previous node.
+     *  Example:
+     *  ```
+     *  // 'bar' is nullable if 'foo' is null.
+     *  // but this function checks regardless of 'foo' type, so returns 'true'.
+     *  declare const foo: { bar : { baz: string } } | null
+     *  foo?.bar;
+     *  ```
+     */
+    function isNullableOriginFromPrev(
+      node: TSESTree.MemberExpression,
+    ): boolean {
+      const prevType = getNodeType(node.object)
+      const property = node.property
+      if (prevType && prevType.isUnion() && property.type === "Identifier") {
+        const isOwnNullable = prevType.types.some((type) => {
+          if (node.computed) {
+            const propertyType = getNodeType(node.property)
+            return Boolean(
+              propertyType && isNullablePropertyType(type, propertyType),
+            )
+          }
+          const propType = getTypeOfPropertyOfType(type, property.name, checker)
+          return propType && isNullableType(propType, ts)
+        })
+        return !isOwnNullable && isNullableType(prevType, ts)
+      }
+      return false
+    }
+
+    /**
+     * Checks whether a lhs expression is optionable or not.
+     */
+    function isOptionableExpression(
+      node: TSESTree.LeftHandSideExpression,
+    ): boolean {
+      const type = getNodeType(node)
+      if (!type) {
+        return false
+      }
+      const isOwnNullable =
+        node.type === "MemberExpression"
+          ? !isNullableOriginFromPrev(node)
+          : true
+      return (
+        isAnyType(type, ts) ||
+        isUnknownType(type, ts) ||
+        (isNullableType(type, ts) && isOwnNullable)
+      )
+    }
+
+    /**
+     * Checks if a conditional node is necessary from the given optional chaining expression.
+     */
+    function checkOptionalChain(
+      node: TSESTree.MemberExpression | TSESTree.CallExpression,
+      beforeOperator: TSESTree.Node,
+      fix: "" | ".",
+    ): void {
+      // We only care if this step in the chain is optional. If just descend
+      // from an optional chain, then that's fine.
+      if (!node.optional) {
+        return
+      }
+
+      // Since typescript array index signature types don't represent the
+      //  possibility of out-of-bounds access, if we're indexing into an array
+      //  just skip the check, to avoid false positives
+      if (optionChainContainsOptionArrayIndex(node)) {
+        return
+      }
+
+      const nodeToCheck =
+        node.type === "CallExpression" ? node.callee : node.object
+
+      if (hasSvelteReactiveVar(nodeToCheck)) {
+        return
+      }
+
+      if (isOptionableExpression(nodeToCheck)) {
+        return
+      }
+
+      const questionDotOperator = sourceCode.getTokenAfter(beforeOperator, {
+        includeComments: false,
+        filter: (token) => token.type === "Punctuator" && token.value === "?.",
+      })!
+
+      context.report({
+        node,
+        loc: questionDotOperator.loc,
+        messageId: "neverOptionalChain",
+        fix(fixer) {
+          return fixer.replaceText(questionDotOperator, fix)
+        },
+      })
+    }
+
+    /**
+     * Checks for optional member expression
+     */
+    function checkOptionalMemberExpression(
+      node: TSESTree.MemberExpression,
+    ): void {
+      checkOptionalChain(node, node.object, node.computed ? "" : ".")
+    }
+
+    /**
+     * Checks for optional call expression
+     */
+    function checkOptionalCallExpression(node: TSESTree.CallExpression): void {
+      checkOptionalChain(node, node.callee, "")
+    }
+
+    return {
+      SvelteReactiveStatement: () => (inSvelteReactiveStatement = true),
+      "SvelteReactiveStatement:exit": () => (inSvelteReactiveStatement = false),
+      BinaryExpression: checkIfBinaryExpressionIsNecessaryConditional,
+      CallExpression: checkCallExpression,
+      ConditionalExpression: (node: TSESTree.ConditionalExpression): void =>
+        checkNode(node.test),
+      DoWhileStatement: checkIfLoopIsNecessaryConditional,
+      ForStatement: checkIfLoopIsNecessaryConditional,
+      IfStatement: (node: TSESTree.IfStatement): void => checkNode(node.test),
+      LogicalExpression: checkLogicalExpressionForUnnecessaryConditionals,
+      WhileStatement: checkIfLoopIsNecessaryConditional,
+      "MemberExpression[optional = true]": checkOptionalMemberExpression,
+      "CallExpression[optional = true]": checkOptionalCallExpression,
+    }
+  },
+})

--- a/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -307,6 +307,12 @@ export default createRule("@typescript-eslint/no-unnecessary-condition", {
       // Since typescript array index signature types don't represent the
       //  possibility of out-of-bounds access, if we're indexing into an array
       //  just skip the check, to avoid false positives
+      if (isArrayIndexExpression(node)) {
+        return
+      }
+
+      // When checking logical expressions, only check the right side
+      //  as the left side has been checked by checkLogicalExpressionForUnnecessaryConditionals
       //
       // Unless the node is nullish coalescing, as it's common to use patterns like `nullBool ?? true` to to strict
       //  boolean checks if we inspect the right here, it'll usually be a constant condition on purpose.

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,12 @@ export interface RuleMetaData {
     description: string
     category: RuleCategory
     recommended: boolean | "base"
-    extensionRule?: string
+    extensionRule?:
+      | string
+      | {
+          plugin: string
+          url: string
+        }
     url: string
     ruleId: string
     ruleName: string
@@ -85,7 +90,12 @@ export interface PartialRuleMetaData {
   docs: {
     description: string
     recommended: boolean | "base"
-    extensionRule?: string
+    extensionRule?:
+      | string
+      | {
+          plugin: string
+          url: string
+        }
     default?: "error" | "warn"
   } & (
     | {

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -1,4 +1,5 @@
 import type { RuleModule } from "../types"
+import typescriptEslintNoUnnecessaryCondition from "../rules/@typescript-eslint/no-unnecessary-condition"
 import buttonHasType from "../rules/button-has-type"
 import commentDirective from "../rules/comment-directive"
 import derivedHasSameInputsOutputs from "../rules/derived-has-same-inputs-outputs"
@@ -40,6 +41,7 @@ import system from "../rules/system"
 import validCompile from "../rules/valid-compile"
 
 export const rules = [
+  typescriptEslintNoUnnecessaryCondition,
   buttonHasType,
   commentDirective,
   derivedHasSameInputsOutputs,

--- a/src/utils/ts-utils/index.ts
+++ b/src/utils/ts-utils/index.ts
@@ -1,0 +1,348 @@
+import type { RuleContext, ASTNode } from "../../types"
+import type * as TS from "typescript"
+import Module from "module"
+import path from "path"
+export type TypeScript = typeof TS
+export type { TS }
+
+export type TSTools = {
+  service: {
+    esTreeNodeToTSNodeMap: ReadonlyMap<unknown, TS.Node>
+    tsNodeToESTreeNodeMap: ReadonlyMap<TS.Node, ASTNode>
+    program: TS.Program
+    hasFullTypeInformation: boolean
+  }
+  ts: TypeScript
+}
+
+/**
+ * Get TypeScript tools
+ */
+export function getTypeScriptTools(context: RuleContext): TSTools | null {
+  const ts = getTypeScript(context)
+  if (!ts) {
+    return null
+  }
+  const { program, esTreeNodeToTSNodeMap, tsNodeToESTreeNodeMap } =
+    context.parserServices
+  if (!program || !esTreeNodeToTSNodeMap || !tsNodeToESTreeNodeMap) {
+    return null
+  }
+  const hasFullTypeInformation =
+    context.parserServices.hasFullTypeInformation ?? true
+
+  if (!hasFullTypeInformation) {
+    // Full type information is required. User must specify parserOptions.project.
+    return null
+  }
+
+  return {
+    service: {
+      esTreeNodeToTSNodeMap,
+      tsNodeToESTreeNodeMap,
+      hasFullTypeInformation,
+      program,
+    },
+    ts,
+  }
+}
+
+let cacheTypeScript: TypeScript | undefined
+/**
+ * Get TypeScript tools
+ */
+export function getTypeScript(context: RuleContext): TypeScript | undefined {
+  if (cacheTypeScript) {
+    return cacheTypeScript
+  }
+  try {
+    const cwd = context.getCwd?.() ?? process.cwd()
+    const relativeTo = path.join(cwd, "__placeholder__.js")
+    cacheTypeScript = Module.createRequire(relativeTo)("typescript")
+  } catch {
+    // ignore
+  }
+  if (cacheTypeScript) {
+    return cacheTypeScript
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
+    cacheTypeScript ??= require("typescript")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignore
+  } catch (e: any) {
+    if (e.code !== "MODULE_NOT_FOUND") {
+      throw e
+    }
+  }
+  return cacheTypeScript
+}
+/**
+ * Check whether the given type is a truthy literal type or not.
+ */
+export function isTruthyLiteral(type: TS.Type, tsTools: TSTools): boolean {
+  if (type.isUnion()) {
+    return type.types.every((t) => isTruthyLiteral(t, tsTools))
+  }
+  return (
+    (isBooleanLiteralType(type, tsTools.ts) &&
+      tsTools.service.program.getTypeChecker().typeToString(type) === "true") ||
+    (type.isLiteral() && Boolean(type.value))
+  )
+}
+
+/**
+ * Check whether the given type is a falsy type or not.
+ */
+export function isFalsyType(type: TS.Type, tsTools: TSTools): boolean {
+  if (type.isUnion()) {
+    return type.types.every((t) => isFalsyType(t, tsTools))
+  }
+  if (
+    isUndefinedType(type, tsTools.ts) ||
+    isNullType(type, tsTools.ts) ||
+    isVoidType(type, tsTools.ts)
+  )
+    return true
+  if (type.isLiteral()) return !type.value
+  return (
+    isBooleanLiteralType(type, tsTools.ts) &&
+    tsTools.service.program.getTypeChecker().typeToString(type) === "false"
+  )
+}
+/**
+ * Check whether the given type is a nullish type or not.
+ */
+export function isNullishType(type: TS.Type, ts: TypeScript): boolean {
+  if (type.isUnion()) {
+    return type.types.every((t) => isNullishType(t, ts))
+  }
+  return isNullType(type, ts) || isUndefinedType(type, ts)
+}
+
+/**
+ * Checks whether the given type is nullable or not.
+ */
+export function isNullableType(type: TS.Type, ts: TypeScript): boolean {
+  if (type.isUnion()) {
+    return type.types.some((t) => isNullableType(t, ts))
+  }
+  return isNullType(type, ts) || isUndefinedType(type, ts)
+}
+/**
+ * Check whether the given type is a boolean literal type or not.
+ */
+export function isBooleanLiteralType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.BooleanLiteral) !== 0
+}
+
+/**
+ * Check whether the given type is an object type or not.
+ */
+export function isObjectType(
+  type: TS.Type,
+  ts: TypeScript,
+): type is TS.ObjectType {
+  return (type.flags & ts.TypeFlags.Object) !== 0
+}
+/**
+ * Check whether the given type is a reference type or not.
+ */
+export function isReferenceObjectType(
+  type: TS.Type,
+  ts: TypeScript,
+): type is TS.TypeReference {
+  return (
+    isObjectType(type, ts) &&
+    (type.objectFlags & ts.ObjectFlags.Reference) !== 0
+  )
+}
+/**
+ * Check whether the given type is a tuple type or not.
+ */
+export function isTupleObjectType(
+  type: TS.Type,
+  ts: TypeScript,
+): type is TS.TupleType {
+  return (
+    isObjectType(type, ts) && (type.objectFlags & ts.ObjectFlags.Tuple) !== 0
+  )
+}
+/**
+ * Check whether the given type is a tuple type or not.
+ * Unlike isTupleObjectType, it also refers to reference types.
+ */
+export function isTupleType(type: TS.Type, ts: TypeScript): boolean {
+  return (
+    isTupleObjectType(type, ts) ||
+    (isReferenceObjectType(type, ts) && isTupleObjectType(type.target, ts))
+  )
+}
+
+/**
+ * Check whether the given type is an any type or not.
+ */
+export function isAnyType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Any) !== 0
+}
+/**
+ * Check whether the given type is an unknown type or not.
+ */
+export function isUnknownType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Unknown) !== 0
+}
+/**
+ * Check whether the given type is a never type or not.
+ */
+export function isNeverType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Never) !== 0
+}
+/**
+ * Check whether the given type is an undefined type or not.
+ */
+export function isUndefinedType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Undefined) !== 0
+}
+/**
+ * Check whether the given type is a void type or not.
+ */
+export function isVoidType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Void) !== 0
+}
+/**
+ * Check whether the given type is a null type or not.
+ */
+export function isNullType(type: TS.Type, ts: TypeScript): boolean {
+  return (type.flags & ts.TypeFlags.Null) !== 0
+}
+/**
+ * Check whether the given type is a possibly falsy type or not.
+ */
+export function isPossiblyFalsyType(type: TS.Type, ts: TypeScript): boolean {
+  if (type.isUnion()) {
+    return type.types.some((t) => isPossiblyFalsyType(t, ts))
+  }
+  return (type.flags & ts.TypeFlags.PossiblyFalsy) !== 0
+}
+
+/**
+ * Get the call signatures from the given type.
+ * This method is heavily inspired by tsutils. https://github.com/ajafff/tsutils
+ * The MIT License (MIT) Copyright (c) 2017 Klaus Meinhardt
+ * https://github.com/ajafff/tsutils/blob/master/LICENSE
+ */
+export function getCallSignaturesOfType(
+  type: TS.Type,
+): readonly TS.Signature[] {
+  if (type.isUnion()) {
+    return type.types.flatMap((t) => getCallSignaturesOfType(t))
+  }
+  if (type.isIntersection()) {
+    let signatures: readonly TS.Signature[] = []
+    for (const t of type.types) {
+      const sig = getCallSignaturesOfType(t)
+      if (sig.length !== 0) {
+        if (signatures.length) {
+          // if more than one type of the intersection has call signatures, none of them is useful for inference
+          return []
+        }
+        signatures = sig
+      }
+    }
+    return signatures
+  }
+  return type.getCallSignatures()
+}
+
+/**
+ * Resolves the given node's type. Will resolve to the type's generic constraint, if it has one.
+ * Copied this method from @typescript-eslint/type-utils. https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/type-utils
+ * The MIT License (MIT) Copyright (c) 2021 TypeScript ESLint and other contributors
+ * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/type-utils/LICENSE
+ */
+export function getConstrainedTypeAtLocation(
+  checker: TS.TypeChecker,
+  node: TS.Node,
+): TS.Type {
+  const nodeType = checker.getTypeAtLocation(node)
+  const constrained = checker.getBaseConstraintOfType(nodeType)
+
+  return constrained ?? nodeType
+}
+
+/**
+ * Get the type name of a given type.
+ *
+ * Copied this method from @typescript-eslint/type-utils. https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/type-utils
+ * The MIT License (MIT) Copyright (c) 2021 TypeScript ESLint and other contributors
+ * https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/type-utils/LICENSE
+ *
+ * @param type The type to get the name of.
+ */
+export function getTypeName(type: TS.Type, tsTools: TSTools): string {
+  const { ts } = tsTools
+  // It handles `string` and string literal types as string.
+  if ((type.flags & ts.TypeFlags.StringLike) !== 0) {
+    return "string"
+  }
+
+  const typeChecker = tsTools.service.program.getTypeChecker()
+
+  // If the type is a type parameter which extends primitive string types,
+  // but it was not recognized as a string like. So check the constraint
+  // type of the type parameter.
+  if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) {
+    // `type.getConstraint()` method doesn't return the constraint type of
+    // the type parameter for some reason. So this gets the constraint type
+    // via AST.
+    const symbol = type.getSymbol()
+    const decls = symbol?.getDeclarations()
+    const typeParamDecl = decls?.[0] as TS.TypeParameterDeclaration
+    if (
+      ts.isTypeParameterDeclaration(typeParamDecl) &&
+      typeParamDecl.constraint != null
+    ) {
+      return getTypeName(
+        typeChecker.getTypeFromTypeNode(typeParamDecl.constraint),
+        tsTools,
+      )
+    }
+  }
+
+  // If the type is a union and all types in the union are string like,
+  // return `string`. For example:
+  // - `"a" | "b"` is string.
+  // - `string | string[]` is not string.
+  if (
+    type.isUnion() &&
+    type.types
+      .map((value) => getTypeName(value, tsTools))
+      .every((t) => t === "string")
+  ) {
+    return "string"
+  }
+
+  // If the type is an intersection and a type in the intersection is string
+  // like, return `string`. For example: `string & {__htmlEscaped: void}`
+  if (
+    type.isIntersection() &&
+    type.types
+      .map((value) => getTypeName(value, tsTools))
+      .some((t) => t === "string")
+  ) {
+    return "string"
+  }
+
+  return typeChecker.typeToString(type)
+}
+
+/**
+ * Return the type of the given property in the given type, or undefined if no such property exists
+ */
+export function getTypeOfPropertyOfType(
+  type: TS.Type,
+  name: string,
+  checker: TS.TypeChecker,
+): TS.Type | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- getTypeOfPropertyOfType is an internal API of TS.
+  return (checker as any).getTypeOfPropertyOfType(type, name)
+}

--- a/src/utils/ts-utils/index.ts
+++ b/src/utils/ts-utils/index.ts
@@ -68,11 +68,8 @@ export function getTypeScript(context: RuleContext): TypeScript | undefined {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- ignore
     cacheTypeScript ??= require("typescript")
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignore
-  } catch (e: any) {
-    if (e.code !== "MODULE_NOT_FOUND") {
-      throw e
-    }
+  } catch {
+    // ignore
   }
   return cacheTypeScript
 }

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-errors.yaml
@@ -2,3 +2,7 @@
   line: 4
   column: 13
   suggestions: null
+- message: Unnecessary conditional, both sides of the expression are literal values.
+  line: 8
+  column: 9
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Unnecessary conditional, both sides of the expression are literal values.
+  line: 4
+  column: 13
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo: null | boolean = null
+
+  const a = foo == null
+  $: b = foo == null
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-input.svelte
@@ -3,4 +3,8 @@
 
   const a = foo == null
   $: b = foo == null
+  $: {
+    let bar: null | boolean = null
+    c = bar == null
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-output.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo: null | boolean = null
+
+  const a = foo == null
+  $: b = foo == null
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/binary-expression01-output.svelte
@@ -3,4 +3,8 @@
 
   const a = foo == null
   $: b = foo == null
+  $: {
+    let bar: null | boolean = null
+    c = bar == null
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-errors.yaml
@@ -1,0 +1,4 @@
+- message: Unnecessary conditional, value is always falsy.
+  line: 4
+  column: 11
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  export let foo: number | null = null
+  /* ✗ BAD */
+  let b = foo || 42
+  /* ✓ GOOD */
+  $: a = foo || 42
+</script>
+
+<!-- ✓ GOOD -->
+{foo || 42}

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/example-output.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  export let foo: number | null = null
+  /* ✗ BAD */
+  let b = foo || 42
+  /* ✓ GOOD */
+  $: a = foo || 42
+</script>
+
+<!-- ✓ GOOD -->
+{foo || 42}

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-errors.yaml
@@ -3,3 +3,8 @@
   line: 5
   column: 13
   suggestions: null
+- message: Unnecessary conditional, left-hand side of `??` operator is always
+    `null` or `undefined`.
+  line: 9
+  column: 9
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-errors.yaml
@@ -1,0 +1,5 @@
+- message: Unnecessary conditional, left-hand side of `??` operator is always
+    `null` or `undefined`.
+  line: 5
+  column: 13
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-input.svelte
@@ -4,4 +4,8 @@
 
   const a = foo ?? bar
   $: b = foo ?? bar
+  $: {
+    let baz: null | boolean = null
+    c = baz ?? bar
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  export let foo: null | boolean = null
+  export let bar: string = "foo"
+
+  const a = foo ?? bar
+  $: b = foo ?? bar
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-output.svelte
@@ -4,4 +4,8 @@
 
   const a = foo ?? bar
   $: b = foo ?? bar
+  $: {
+    let baz: null | boolean = null
+    c = baz ?? bar
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/nullish-coalescing01-output.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  export let foo: null | boolean = null
+  export let bar: string = "foo"
+
+  const a = foo ?? bar
+  $: b = foo ?? bar
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Unnecessary optional chain on a non-nullish value.
+  line: 4
+  column: 16
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-errors.yaml
@@ -2,3 +2,7 @@
   line: 4
   column: 16
   suggestions: null
+- message: Unnecessary optional chain on a non-nullish value.
+  line: 8
+  column: 12
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-input.svelte
@@ -3,4 +3,8 @@
 
   const a = foo?.length
   $: b = foo?.length
+  $: {
+    let bar: null | string = "abc"
+    c = bar?.length
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo: null | string = "abc"
+
+  const a = foo?.length
+  $: b = foo?.length
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-output.svelte
@@ -3,4 +3,8 @@
 
   const a = foo.length
   $: b = foo?.length
+  $: {
+    let bar: null | string = "abc"
+    c = bar.length
+  }
 </script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/optional-chaining01-output.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo: null | string = "abc"
+
+  const a = foo.length
+  $: b = foo?.length
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-errors.yaml
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-errors.yaml
@@ -1,0 +1,4 @@
+- message: Unnecessary conditional, value is always truthy.
+  line: 5
+  column: 14
+  suggestions: null

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo = false
+  export let bar: string | undefined = undefined
+
+  const a = !foo && bar
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-output.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/invalid/test01-output.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo = false
+  export let bar: string | undefined = undefined
+
+  const a = !foo && bar
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/valid/reactive-statement01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/valid/reactive-statement01-input.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  export let foo = false
+  export let bar: string | undefined = undefined
+
+  $: a = !foo && bar
+</script>

--- a/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/valid/template01-input.svelte
+++ b/tests/fixtures/rules/@typescript-eslint/no-unnecessary-condition/valid/template01-input.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  let foo = false
+
+  let bar: string | undefined = undefined
+</script>
+
+<button on:click={() => (foo = !foo)} />
+
+{#if !foo}
+  <div>{bar}</div>
+{/if}
+
+{#if !foo && bar}
+  <div>{bar}</div>
+{/if}

--- a/tests/fixtures/rules/tsconfig.json
+++ b/tests/fixtures/rules/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["**/*.svelte"]
+}

--- a/tests/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/tests/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -1,0 +1,21 @@
+import { RuleTester } from "eslint"
+import rule from "../../../../src/rules/@typescript-eslint/no-unnecessary-condition"
+import { loadTestCases, RULES_PROJECT } from "../../../utils/utils"
+
+const tester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+    parser: {
+      ts: "@typescript-eslint/parser",
+      js: "espree",
+    },
+    project: RULES_PROJECT,
+  },
+})
+
+tester.run(
+  "@typescript-eslint/no-unnecessary-condition",
+  rule as any,
+  loadTestCases("@typescript-eslint/no-unnecessary-condition"),
+)

--- a/tests/src/rules/@typescript-eslint/original-tests/RuleTester.ts
+++ b/tests/src/rules/@typescript-eslint/original-tests/RuleTester.ts
@@ -1,0 +1,15 @@
+import { ESLintUtils } from "@typescript-eslint/utils"
+import * as path from "path"
+
+function getFixturesRootDir(): string {
+  return path.join(__dirname, "fixtures")
+}
+
+const {
+  batchedSingleLineTests,
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- original name
+  RuleTester,
+  noFormat,
+} = ESLintUtils
+
+export { batchedSingleLineTests, getFixturesRootDir, noFormat, RuleTester }

--- a/tests/src/rules/@typescript-eslint/original-tests/fixtures/tsconfig.json
+++ b/tests/src/rules/@typescript-eslint/original-tests/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["file.ts", "react.tsx"]
+}

--- a/tests/src/rules/@typescript-eslint/original-tests/fixtures/unstrict/tsconfig.json
+++ b/tests/src/rules/@typescript-eslint/original-tests/fixtures/unstrict/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": false,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["file.ts", "react.tsx"]
+}

--- a/tests/src/rules/@typescript-eslint/original-tests/no-unnecessary-condition.ts
+++ b/tests/src/rules/@typescript-eslint/original-tests/no-unnecessary-condition.ts
@@ -1,0 +1,1544 @@
+// Original test cases
+// https://github.com/typescript-eslint/typescript-eslint/blob/78467fc1bde9bd2db1e08b3d19f151f4adaff8a9/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+/* eslint func-style: off, eslint-plugin/consistent-output: off -- respect original  */
+import type {
+  InvalidTestCase,
+  TestCaseError,
+} from "@typescript-eslint/utils/dist/ts-eslint"
+import * as path from "path"
+
+import rule from "../../../../../src/rules/@typescript-eslint/no-unnecessary-condition"
+import { getFixturesRootDir, noFormat, RuleTester } from "./RuleTester"
+
+const rootPath = getFixturesRootDir()
+
+const ruleTester = new RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    tsconfigRootDir: rootPath,
+    project: "./tsconfig.json",
+  },
+})
+
+const ruleError = (
+  line: number,
+  column: number,
+  messageId: string,
+): TestCaseError<string> => ({
+  messageId,
+  line,
+  column,
+})
+
+const necessaryConditionTest = (condition: string): string => `
+declare const b1: ${condition};
+declare const b2: boolean;
+const t1 = b1 && b2;
+`
+
+const unnecessaryConditionTest = (
+  condition: string,
+  messageId: string,
+): InvalidTestCase<string, any> => ({
+  code: necessaryConditionTest(condition),
+  errors: [ruleError(4, 12, messageId)],
+})
+
+ruleTester.run("no-unnecessary-conditionals", rule as any, {
+  valid: [
+    `
+declare const b1: boolean;
+declare const b2: boolean;
+const t1 = b1 && b2;
+const t2 = b1 || b2;
+if (b1 && b2) {
+}
+while (b1 && b2) {}
+for (let i = 0; b1 && b2; i++) {
+  break;
+}
+const t1 = b1 && b2 ? 'yes' : 'no';
+if (b1 && b2) {
+}
+while (b1 && b2) {}
+for (let i = 0; b1 && b2; i++) {
+  break;
+}
+const t1 = b1 && b2 ? 'yes' : 'no';
+for (;;) {}
+    `,
+    necessaryConditionTest("false | 5"), // Truthy literal and falsy literal
+    necessaryConditionTest('boolean | "foo"'), // boolean and truthy literal
+    necessaryConditionTest("0 | boolean"), // boolean and falsy literal
+    necessaryConditionTest("boolean | object"), // boolean and always-truthy type
+    necessaryConditionTest("false | object"), // always truthy type and falsy literal
+    // always falsy type and always truthy type
+    necessaryConditionTest("null | object"),
+    necessaryConditionTest("undefined | true"),
+    necessaryConditionTest("void | true"),
+
+    necessaryConditionTest("any"), // any
+    necessaryConditionTest("unknown"), // unknown
+
+    // Generic type params
+    `
+function test<T extends string>(t: T) {
+  return t ? 'yes' : 'no';
+}
+    `,
+    `
+// Naked type param
+function test<T>(t: T) {
+  return t ? 'yes' : 'no';
+}
+    `,
+    `
+// Naked type param in union
+function test<T>(t: T | []) {
+  return t ? 'yes' : 'no';
+}
+    `,
+
+    // Boolean expressions
+    `
+function test(a: string) {
+  const t1 = a === 'a';
+  const t2 = 'a' === a;
+}
+    `,
+    `
+function test(a?: string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t1 = a !== undefined;
+  const t2 = undefined !== a;
+}
+    `,
+    `
+function test(a: null | string) {
+  const t1 = a === null;
+  const t2 = null === a;
+  const t1 = a !== null;
+  const t2 = null !== a;
+}
+    `,
+    `
+function test(a?: null | string) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+}
+    `,
+    `
+function test(a?: string) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+}
+    `,
+    `
+function test(a: null | string) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+}
+    `,
+    `
+function test(a: any) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+  const t9 = a === null;
+  const t10 = null === a;
+  const t11 = a !== null;
+  const t12 = null !== a;
+  const t13 = a === undefined;
+  const t14 = undefined === a;
+  const t15 = a !== undefined;
+  const t16 = undefined !== a;
+}
+    `,
+    `
+function test(a: unknown) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+  const t9 = a === null;
+  const t10 = null === a;
+  const t11 = a !== null;
+  const t12 = null !== a;
+  const t13 = a === undefined;
+  const t14 = undefined === a;
+  const t15 = a !== undefined;
+  const t16 = undefined !== a;
+}
+    `,
+    `
+function test<T>(a: T) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+  const t9 = a === null;
+  const t10 = null === a;
+  const t11 = a !== null;
+  const t12 = null !== a;
+  const t13 = a === undefined;
+  const t14 = undefined === a;
+  const t15 = a !== undefined;
+  const t16 = undefined !== a;
+}
+    `,
+
+    //
+    // Predicate functions
+    //
+    `
+// with literal arrow function
+[0, 1, 2].filter(x => x);
+
+// filter with named function
+function length(x: string) {
+  return x.length;
+}
+['a', 'b', ''].filter(length);
+
+// with non-literal array
+function nonEmptyStrings(x: string[]) {
+  return x.filter(length);
+}
+
+// filter-like predicate
+function count(
+  list: string[],
+  predicate: (value: string, index: number, array: string[]) => unknown,
+) {
+  return list.filter(predicate).length;
+}
+    `,
+    // Ignores non-array methods of the same name
+    `
+const notArray = {
+  filter: (func: () => boolean) => func(),
+  find: (func: () => boolean) => func(),
+};
+notArray.filter(() => true);
+notArray.find(() => true);
+    `,
+
+    // Nullish coalescing operator
+    `
+function test(a: string | null) {
+  return a ?? 'default';
+}
+    `,
+    `
+function test(a: string | undefined) {
+  return a ?? 'default';
+}
+    `,
+    `
+function test(a: string | null | undefined) {
+  return a ?? 'default';
+}
+    `,
+    `
+function test(a: unknown) {
+  return a ?? 'default';
+}
+    `,
+    // Indexing cases
+    `
+declare const arr: object[];
+if (arr[42]) {
+} // looks unnecessary from the types, but isn't
+
+const tuple = [{}] as [object];
+declare const n: number;
+if (tuple[n]) {
+}
+    `,
+    // Optional-chaining indexing
+    `
+declare const arr: Array<{ value: string } & (() => void)>;
+if (arr[42]?.value) {
+}
+arr[41]?.();
+
+// An array access can "infect" deeper into the chain
+declare const arr2: Array<{ x: { y: { z: object } } }>;
+arr2[42]?.x?.y?.z;
+
+const tuple = ['foo'] as const;
+declare const n: number;
+tuple[n]?.toUpperCase();
+    `,
+    `
+if (arr?.[42]) {
+}
+    `,
+    `
+declare const returnsArr: undefined | (() => string[]);
+if (returnsArr?.()[42]) {
+}
+returnsArr?.()[42]?.toUpperCase();
+    `,
+    // nullish + array index
+    `
+declare const arr: string[][];
+arr[x] ?? [];
+    `,
+    // nullish + optional array index
+    `
+declare const arr: { foo: number }[];
+const bar = arr[42]?.foo ?? 0;
+    `,
+    // Doesn't check the right-hand side of a logical expression
+    //  in a non-conditional context
+    `
+declare const b1: boolean;
+declare const b2: true;
+const x = b1 && b2;
+      `,
+    {
+      code: `
+while (true) {}
+for (; true; ) {}
+do {} while (true);
+      `,
+      options: [{ allowConstantLoopConditions: true }],
+    },
+    `
+let foo: undefined | { bar: true };
+foo?.bar;
+    `,
+    `
+let foo: null | { bar: true };
+foo?.bar;
+    `,
+    `
+let foo: undefined;
+foo?.bar;
+    `,
+    `
+let foo: undefined;
+foo?.bar.baz;
+    `,
+    `
+let foo: null;
+foo?.bar;
+    `,
+    `
+let anyValue: any;
+anyValue?.foo;
+    `,
+    `
+let unknownValue: unknown;
+unknownValue?.foo;
+    `,
+    `
+let foo: undefined | (() => {});
+foo?.();
+    `,
+    `
+let foo: null | (() => {});
+foo?.();
+    `,
+    `
+let foo: undefined;
+foo?.();
+    `,
+    `
+let foo: undefined;
+foo?.().bar;
+    `,
+    `
+let foo: null;
+foo?.();
+    `,
+    `
+let anyValue: any;
+anyValue?.();
+    `,
+    `
+let unknownValue: unknown;
+unknownValue?.();
+    `,
+    "const foo = [1, 2, 3][0];",
+    `
+declare const foo: { bar?: { baz: { c: string } } } | null;
+foo?.bar?.baz;
+    `,
+    `
+foo?.bar?.baz?.qux;
+    `,
+    `
+declare const foo: { bar: { baz: string } };
+foo.bar.qux?.();
+    `,
+    `
+type Foo = { baz: number } | null;
+type Bar = { baz: null | string | { qux: string } };
+declare const foo: { fooOrBar: Foo | Bar } | null;
+foo?.fooOrBar?.baz?.qux;
+    `,
+    `
+type Foo = { [key: string]: string } | null;
+declare const foo: Foo;
+
+const key = '1';
+foo?.[key]?.trim();
+    `,
+    `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+type Key = 'bar' | 'foo';
+declare const foo: Foo;
+declare const key: Key;
+
+foo?.[key].trim();
+    `,
+    `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+  };
+}
+
+function Foo(outer: Outer, key: string): number | undefined {
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+    `,
+    `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+type Foo = 'foo';
+
+function Foo(outer: Outer, key: Foo): number | undefined {
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+    `,
+    `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+type Key = 'bar' | 'foo' | 'baz';
+declare const foo: Foo;
+declare const key: Key;
+
+foo?.[key]?.trim();
+    `,
+    `
+let latencies: number[][] = [];
+
+function recordData(): void {
+  if (!latencies[0]) latencies[0] = [];
+  latencies[0].push(4);
+}
+
+recordData();
+    `,
+    `
+let latencies: number[][] = [];
+
+function recordData(): void {
+  if (latencies[0]) latencies[0] = [];
+  latencies[0].push(4);
+}
+
+recordData();
+    `,
+    `
+function test(testVal?: boolean) {
+  if (testVal ?? true) {
+    console.log('test');
+  }
+}
+    `,
+    `
+declare const x: string[];
+if (!x[0]) {
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2421
+    `
+const isEven = (val: number) => val % 2 === 0;
+if (!isEven(1)) {
+}
+    `,
+    `
+declare const booleanTyped: boolean;
+declare const unknownTyped: unknown;
+
+if (!(booleanTyped || unknownTyped)) {
+}
+    `,
+    {
+      code: `
+declare const x: string[] | null;
+// eslint-disable-next-line
+if (x) {
+}
+      `,
+      options: [
+        {
+          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
+        },
+      ],
+      parserOptions: {
+        tsconfigRootDir: path.join(rootPath, "unstrict"),
+      },
+    },
+  ],
+  invalid: [
+    // Ensure that it's checking in all the right places
+    {
+      code: `
+const b1 = true;
+declare const b2: boolean;
+const t1 = b1 && b2;
+const t2 = b1 || b2;
+if (b1 && b2) {
+}
+if (b2 && b1) {
+}
+while (b1 && b2) {}
+while (b2 && b1) {}
+for (let i = 0; b1 && b2; i++) {
+  break;
+}
+const t1 = b1 && b2 ? 'yes' : 'no';
+const t1 = b2 && b1 ? 'yes' : 'no';
+      `,
+      errors: [
+        ruleError(4, 12, "alwaysTruthy"),
+        ruleError(5, 12, "alwaysTruthy"),
+        ruleError(6, 5, "alwaysTruthy"),
+        ruleError(8, 11, "alwaysTruthy"),
+        ruleError(10, 8, "alwaysTruthy"),
+        ruleError(11, 14, "alwaysTruthy"),
+        ruleError(12, 17, "alwaysTruthy"),
+        ruleError(15, 12, "alwaysTruthy"),
+        ruleError(16, 18, "alwaysTruthy"),
+      ],
+    },
+    // Ensure that it's complaining about the right things
+    unnecessaryConditionTest("object", "alwaysTruthy"),
+    unnecessaryConditionTest("object | true", "alwaysTruthy"),
+    unnecessaryConditionTest('"" | false', "alwaysFalsy"), // Two falsy literals
+    unnecessaryConditionTest('"always truthy"', "alwaysTruthy"),
+    unnecessaryConditionTest(`undefined`, "alwaysFalsy"),
+    unnecessaryConditionTest("null", "alwaysFalsy"),
+    unnecessaryConditionTest("void", "alwaysFalsy"),
+    unnecessaryConditionTest("never", "never"),
+
+    // More complex logical expressions
+    {
+      code: `
+declare const b1: boolean;
+declare const b2: boolean;
+if (true && b1 && b2) {
+}
+if (b1 && false && b2) {
+}
+if (b1 || b2 || true) {
+}
+      `,
+      errors: [
+        ruleError(4, 5, "alwaysTruthy"),
+        ruleError(6, 11, "alwaysFalsy"),
+        ruleError(8, 17, "alwaysTruthy"),
+      ],
+    },
+
+    // Generic type params
+    {
+      code: `
+function test<T extends object>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      `,
+      errors: [ruleError(3, 10, "alwaysTruthy")],
+    },
+    {
+      code: `
+function test<T extends false>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      `,
+      errors: [ruleError(3, 10, "alwaysFalsy")],
+    },
+    {
+      code: `
+function test<T extends 'a' | 'b'>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      `,
+      errors: [ruleError(3, 10, "alwaysTruthy")],
+    },
+
+    // Boolean expressions
+    {
+      code: `
+function test(a: 'a') {
+  return a === 'a';
+}
+      `,
+      errors: [ruleError(3, 10, "literalBooleanExpression")],
+    },
+    {
+      code: `
+const y = 1;
+if (y === 0) {
+}
+      `,
+      errors: [ruleError(3, 5, "literalBooleanExpression")],
+    },
+    {
+      code: `
+enum Foo {
+  a = 1,
+  b = 2,
+}
+
+const x = Foo.a;
+if (x === Foo.a) {
+}
+      `,
+      errors: [ruleError(8, 5, "literalBooleanExpression")],
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/37160
+    {
+      code: `
+function test(a: string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      `,
+      errors: [
+        ruleError(3, 14, "noOverlapBooleanExpression"),
+        ruleError(4, 14, "noOverlapBooleanExpression"),
+        ruleError(5, 14, "noOverlapBooleanExpression"),
+        ruleError(6, 14, "noOverlapBooleanExpression"),
+        ruleError(7, 14, "noOverlapBooleanExpression"),
+        ruleError(8, 14, "noOverlapBooleanExpression"),
+        ruleError(9, 14, "noOverlapBooleanExpression"),
+        ruleError(10, 14, "noOverlapBooleanExpression"),
+      ],
+    },
+    {
+      code: `
+function test(a?: string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      `,
+      errors: [
+        ruleError(7, 14, "noOverlapBooleanExpression"),
+        ruleError(8, 14, "noOverlapBooleanExpression"),
+        ruleError(9, 14, "noOverlapBooleanExpression"),
+        ruleError(10, 14, "noOverlapBooleanExpression"),
+      ],
+    },
+    {
+      code: `
+function test(a: null | string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      `,
+      errors: [
+        ruleError(3, 14, "noOverlapBooleanExpression"),
+        ruleError(4, 14, "noOverlapBooleanExpression"),
+        ruleError(5, 14, "noOverlapBooleanExpression"),
+        ruleError(6, 14, "noOverlapBooleanExpression"),
+      ],
+    },
+    {
+      code: `
+function test<T extends object>(a: T) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+  const t9 = a === null;
+  const t10 = null === a;
+  const t11 = a !== null;
+  const t12 = null !== a;
+  const t13 = a === undefined;
+  const t14 = undefined === a;
+  const t15 = a !== undefined;
+  const t16 = undefined !== a;
+}
+      `,
+      errors: [
+        ruleError(3, 14, "noOverlapBooleanExpression"),
+        ruleError(4, 14, "noOverlapBooleanExpression"),
+        ruleError(5, 14, "noOverlapBooleanExpression"),
+        ruleError(6, 14, "noOverlapBooleanExpression"),
+        ruleError(7, 14, "noOverlapBooleanExpression"),
+        ruleError(8, 14, "noOverlapBooleanExpression"),
+        ruleError(9, 14, "noOverlapBooleanExpression"),
+        ruleError(10, 14, "noOverlapBooleanExpression"),
+        ruleError(11, 14, "noOverlapBooleanExpression"),
+        ruleError(12, 15, "noOverlapBooleanExpression"),
+        ruleError(13, 15, "noOverlapBooleanExpression"),
+        ruleError(14, 15, "noOverlapBooleanExpression"),
+        ruleError(15, 15, "noOverlapBooleanExpression"),
+        ruleError(16, 15, "noOverlapBooleanExpression"),
+        ruleError(17, 15, "noOverlapBooleanExpression"),
+        ruleError(18, 15, "noOverlapBooleanExpression"),
+      ],
+    },
+    // Nullish coalescing operator
+    {
+      code: `
+function test(a: string) {
+  return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "neverNullish")],
+    },
+    {
+      code: `
+function test(a: string | false) {
+  return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "neverNullish")],
+    },
+    // nullish + array index without optional chaining
+    {
+      code: `
+function test(a: { foo: string }[]) {
+  return a[0].foo ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "neverNullish")],
+    },
+    {
+      code: `
+function test(a: null) {
+  return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "alwaysNullish")],
+    },
+    {
+      code: `
+function test(a: null[]) {
+  return a[0] ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "alwaysNullish")],
+    },
+    {
+      code: `
+function test(a: never) {
+  return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, "never")],
+    },
+
+    // Predicate functions
+    {
+      code: `
+[1, 3, 5].filter(() => true);
+[1, 2, 3].find(() => {
+  return false;
+});
+
+// with non-literal array
+function nothing(x: string[]) {
+  return x.filter(() => false);
+}
+// with readonly array
+function nothing2(x: readonly string[]) {
+  return x.filter(() => false);
+}
+// with tuple
+function nothing3(x: [string, string]) {
+  return x.filter(() => false);
+}
+      `,
+      errors: [
+        ruleError(2, 24, "alwaysTruthy"),
+        ruleError(4, 10, "alwaysFalsy"),
+        ruleError(9, 25, "alwaysFalsy"),
+        ruleError(13, 25, "alwaysFalsy"),
+        ruleError(17, 25, "alwaysFalsy"),
+      ],
+    },
+    // Indexing cases
+    {
+      // This is an error because 'dict' doesn't represent
+      //  the potential for undefined in its types
+      code: `
+declare const dict: Record<string, object>;
+if (dict['mightNotExist']) {
+}
+      `,
+      errors: [ruleError(3, 5, "alwaysTruthy")],
+    },
+    {
+      // Should still check tuples when accessed with literal numbers, since they don't have
+      //   unsound index signatures
+      code: `
+const x = [{}] as [{ foo: string }];
+if (x[0]) {
+}
+if (x[0]?.foo) {
+}
+      `,
+      output: `
+const x = [{}] as [{ foo: string }];
+if (x[0]) {
+}
+if (x[0].foo) {
+}
+      `,
+      errors: [
+        ruleError(3, 5, "alwaysTruthy"),
+        ruleError(5, 9, "neverOptionalChain"),
+      ],
+    },
+    {
+      // Shouldn't mistake this for an array indexing case
+      code: `
+declare const arr: object[];
+if (arr.filter) {
+}
+      `,
+      errors: [ruleError(3, 5, "alwaysTruthy")],
+    },
+    {
+      code: `
+function truthy() {
+  return [];
+}
+function falsy() {}
+[1, 3, 5].filter(truthy);
+[1, 2, 3].find(falsy);
+      `,
+      errors: [
+        ruleError(6, 18, "alwaysTruthyFunc"),
+        ruleError(7, 16, "alwaysFalsyFunc"),
+      ],
+    },
+    // Supports generics
+    // TODO: fix this
+    //     {
+    //       code: `
+    // const isTruthy = <T>(t: T) => T;
+    // // Valid: numbers can be truthy or falsy (0).
+    // [0,1,2,3].filter(isTruthy);
+    // // Invalid: arrays are always falsy.
+    // [[1,2], [3,4]].filter(isTruthy);
+    // `,
+    //       errors: [ruleError(6, 23, 'alwaysTruthyFunc')],
+    //     },
+    {
+      code: `
+while (true) {}
+for (; true; ) {}
+do {} while (true);
+      `,
+      options: [{ allowConstantLoopConditions: false }],
+      errors: [
+        ruleError(2, 8, "alwaysTruthy"),
+        ruleError(3, 8, "alwaysTruthy"),
+        ruleError(4, 14, "alwaysTruthy"),
+      ],
+    },
+    {
+      code: noFormat`
+let foo = { bar: true };
+foo?.bar;
+foo ?. bar;
+foo ?.
+  bar;
+foo
+  ?. bar;
+      `,
+      output: `
+let foo = { bar: true };
+foo.bar;
+foo . bar;
+foo .
+  bar;
+foo
+  . bar;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          column: 4,
+          endLine: 3,
+          endColumn: 6,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 5,
+          column: 5,
+          endLine: 5,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 8,
+          column: 3,
+          endLine: 8,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+let foo = () => {};
+foo?.();
+foo ?. ();
+foo ?.
+  ();
+foo
+  ?. ();
+      `,
+      output: `
+let foo = () => {};
+foo();
+foo  ();
+foo${" "}
+  ();
+foo
+   ();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          column: 4,
+          endLine: 3,
+          endColumn: 6,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 5,
+          column: 5,
+          endLine: 5,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 8,
+          column: 3,
+          endLine: 8,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+let foo = () => {};
+foo?.(bar);
+foo ?. (bar);
+foo ?.
+  (bar);
+foo
+  ?. (bar);
+      `,
+      output: `
+let foo = () => {};
+foo(bar);
+foo  (bar);
+foo${" "}
+  (bar);
+foo
+   (bar);
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          column: 4,
+          endLine: 3,
+          endColumn: 6,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 5,
+          column: 5,
+          endLine: 5,
+          endColumn: 7,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 8,
+          column: 3,
+          endLine: 8,
+          endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: "const foo = [1, 2, 3]?.[0];",
+      output: "const foo = [1, 2, 3][0];",
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 1,
+          endLine: 1,
+          column: 22,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: { a?: { b: string } };
+x?.a?.b;
+      `,
+      output: `
+declare const x: { a?: { b: string } };
+x.a?.b;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 2,
+          endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: { a: { b?: { c: string } } };
+x.a?.b?.c;
+      `,
+      output: `
+declare const x: { a: { b?: { c: string } } };
+x.a.b?.c;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 4,
+          endColumn: 6,
+        },
+      ],
+    },
+    {
+      code: `
+let x: { a?: string };
+x?.a;
+      `,
+      output: `
+let x: { a?: string };
+x.a;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 2,
+          endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar: { baz: { c: string } } } | null;
+foo?.bar?.baz;
+      `,
+      output: `
+declare const foo: { bar: { baz: { c: string } } } | null;
+foo?.bar.baz;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 9,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar?: { baz: { qux: string } } } | null;
+foo?.bar?.baz?.qux;
+      `,
+      output: `
+declare const foo: { bar?: { baz: { qux: string } } } | null;
+foo?.bar?.baz.qux;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 14,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar: { baz: { qux?: () => {} } } } | null;
+foo?.bar?.baz?.qux?.();
+      `,
+      output: `
+declare const foo: { bar: { baz: { qux?: () => {} } } } | null;
+foo?.bar.baz.qux?.();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 9,
+          endColumn: 11,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 14,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar: { baz: { qux: () => {} } } } | null;
+foo?.bar?.baz?.qux?.();
+      `,
+      output: `
+declare const foo: { bar: { baz: { qux: () => {} } } } | null;
+foo?.bar.baz.qux();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 9,
+          endColumn: 11,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 14,
+          endColumn: 16,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 3,
+          endLine: 3,
+          column: 19,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: `
+type baz = () => { qux: () => {} };
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.().qux?.();
+      `,
+      output: `
+type baz = () => { qux: () => {} };
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar.baz().qux();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 9,
+          endColumn: 11,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 14,
+          endColumn: 16,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 22,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `
+type baz = null | (() => { qux: () => {} });
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.().qux?.();
+      `,
+      output: `
+type baz = null | (() => { qux: () => {} });
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar.baz?.().qux();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 9,
+          endColumn: 11,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 22,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `
+type baz = null | (() => { qux: () => {} } | null);
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.()?.qux?.();
+      `,
+      output: `
+type baz = null | (() => { qux: () => {} } | null);
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar.baz?.()?.qux();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 9,
+          endColumn: 11,
+        },
+        {
+          messageId: "neverOptionalChain",
+          line: 4,
+          endLine: 4,
+          column: 23,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = { baz: number };
+type Bar = { baz: null | string | { qux: string } };
+declare const foo: { fooOrBar: Foo | Bar } | null;
+foo?.fooOrBar?.baz?.qux;
+      `,
+      output: `
+type Foo = { baz: number };
+type Bar = { baz: null | string | { qux: string } };
+declare const foo: { fooOrBar: Foo | Bar } | null;
+foo?.fooOrBar.baz?.qux;
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 5,
+          endLine: 5,
+          column: 14,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: { a: { b: number } }[];
+x[0].a?.b;
+      `,
+      output: `
+declare const x: { a: { b: number } }[];
+x[0].a.b;
+      `,
+      errors: [ruleError(3, 7, "neverOptionalChain")],
+    },
+    {
+      code: `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+type Key = 'bar' | 'foo';
+declare const foo: Foo;
+declare const key: Key;
+
+foo?.[key]?.trim();
+      `,
+      output: `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+type Key = 'bar' | 'foo';
+declare const foo: Foo;
+declare const key: Key;
+
+foo?.[key].trim();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 7,
+          endLine: 7,
+          column: 11,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+declare const foo: Foo;
+const key = 'bar';
+foo?.[key]?.trim();
+      `,
+      output: `
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+declare const foo: Foo;
+const key = 'bar';
+foo?.[key].trim();
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 5,
+          endLine: 5,
+          column: 11,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+
+export function test(outer: Outer): number | undefined {
+  const key = 'bar';
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+      `,
+      output: `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+
+export function test(outer: Outer): number | undefined {
+  const key = 'bar';
+  return outer.inner?.[key].charCodeAt(0);
+}
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 11,
+          endLine: 11,
+          column: 28,
+          endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+type Bar = 'bar';
+
+function Foo(outer: Outer, key: Bar): number | undefined {
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+      `,
+      output: `
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+type Bar = 'bar';
+
+function Foo(outer: Outer, key: Bar): number | undefined {
+  return outer.inner?.[key].charCodeAt(0);
+}
+      `,
+      errors: [
+        {
+          messageId: "neverOptionalChain",
+          line: 11,
+          endLine: 11,
+          column: 28,
+          endColumn: 30,
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2384
+    {
+      code: `
+function test(testVal?: true) {
+  if (testVal ?? true) {
+    console.log('test');
+  }
+}
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: "alwaysTruthy",
+          line: 3,
+          endLine: 3,
+          column: 7,
+          endColumn: 22,
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2255
+    {
+      code: `
+const a = null;
+if (!a) {
+}
+      `,
+      errors: [ruleError(3, 6, "alwaysTruthy")],
+    },
+    {
+      code: `
+const a = true;
+if (!a) {
+}
+      `,
+      errors: [ruleError(3, 6, "alwaysFalsy")],
+    },
+    {
+      code: `
+function sayHi(): void {
+  console.log('Hi!');
+}
+
+let speech: never = sayHi();
+if (!speech) {
+}
+      `,
+      errors: [ruleError(7, 6, "never")],
+    },
+    {
+      code: `
+declare const x: string[] | null;
+if (x) {
+}
+      `,
+      parserOptions: {
+        tsconfigRootDir: path.join(rootPath, "unstrict"),
+      },
+      errors: [
+        {
+          messageId: "noStrictNullCheck",
+          line: 0,
+          column: 1,
+        },
+        {
+          messageId: "alwaysTruthy",
+          line: 3,
+          column: 5,
+        },
+      ],
+    },
+  ],
+})

--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -52,6 +52,19 @@ function getMinIndent(lines: string[]) {
   return Math.min(...lineIndents)
 }
 
+export const FIXTURES_ROOT = path.resolve(__dirname, `../fixtures/`)
+export const RULES_PROJECT = path.resolve(
+  FIXTURES_ROOT,
+  "./rules/tsconfig.json",
+)
+
+/**
+ * Get the rule fixtures root directory
+ */
+export function getRuleFixturesRoot(ruleName: string): string {
+  return path.resolve(FIXTURES_ROOT, `./rules/${ruleName}`)
+}
+
 /**
  * Load test cases
  */
@@ -68,14 +81,9 @@ export function loadTestCases(
   valid: RuleTester.ValidTestCase[]
   invalid: RuleTester.InvalidTestCase[]
 } {
-  const validFixtureRoot = path.resolve(
-    __dirname,
-    `../fixtures/rules/${ruleName}/valid/`,
-  )
-  const invalidFixtureRoot = path.resolve(
-    __dirname,
-    `../fixtures/rules/${ruleName}/invalid/`,
-  )
+  const rootDir = getRuleFixturesRoot(ruleName)
+  const validFixtureRoot = path.resolve(rootDir, `./valid/`)
+  const invalidFixtureRoot = path.resolve(rootDir, `./invalid/`)
 
   const filter = options?.filter ?? (() => true)
 
@@ -200,6 +208,7 @@ function writeFixtures(
           ts: "@typescript-eslint/parser",
           js: "espree",
         },
+        ...config.parserOptions,
       },
     },
     config.filename,
@@ -261,5 +270,19 @@ function getConfig(ruleName: string, inputFile: string) {
       ? require.resolve("svelte-eslint-parser")
       : undefined
 
-  return Object.assign({ parser }, config, { code, filename })
+  return Object.assign(
+    {
+      parser,
+      parserOptions: {
+        project: RULES_PROJECT,
+        parser: {
+          ts: "@typescript-eslint/parser",
+          js: "espree",
+        },
+        extraFileExtensions: [".svelte"],
+      },
+    },
+    config,
+    { code, filename: inputFile },
+  )
 }

--- a/tools/lib/load-rules.ts
+++ b/tools/lib/load-rules.ts
@@ -8,13 +8,15 @@ import fs from "fs"
 function readRules() {
   const rulesLibRoot = path.resolve(__dirname, "../../src/rules")
   const rules = []
-  for (const name of fs
-    .readdirSync(rulesLibRoot)
-    .filter((n) => n.endsWith(".ts"))) {
+  for (const name of iterateTsFiles()) {
     const ruleName = name.replace(/\.ts$/u, "")
     const ruleId = `svelte/${ruleName}`
     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports -- ignore
-    const rule = require(path.join(rulesLibRoot, name)).default
+    const module = require(path.join(rulesLibRoot, name))
+    const rule = module && module.default
+    if (!rule || typeof rule.create !== "function") {
+      continue
+    }
 
     rule.meta.docs.ruleName = ruleName
     rule.meta.docs.ruleId = ruleId
@@ -25,3 +27,22 @@ function readRules() {
 }
 
 export const rules = readRules()
+
+/** Iterate ts files */
+function* iterateTsFiles() {
+  const rulesLibRoot = path.resolve(__dirname, "../../src/rules")
+  const files = fs.readdirSync(rulesLibRoot)
+
+  while (files.length) {
+    const file = files.shift()!
+    if (file.endsWith(".ts")) {
+      yield file
+      continue
+    }
+    const filePath = path.join(rulesLibRoot, file)
+    if (!fs.statSync(filePath).isDirectory()) {
+      continue
+    }
+    files.unshift(...fs.readdirSync(filePath).map((n) => path.join(file, n)))
+  }
+}

--- a/tools/render-rules.ts
+++ b/tools/render-rules.ts
@@ -20,7 +20,7 @@ const descriptions: Record<typeof categories[number], string> = {
   "Stylistic Issues":
     "These rules relate to style guidelines, and are therefore quite subjective:",
   "Extension Rules":
-    "These rules extend the rules provided by ESLint itself to work well in Svelte:",
+    "These rules extend the rules provided by ESLint itself, or other plugins to work well in Svelte:",
   System: "These rules relate to this plugin works:",
 }
 

--- a/tools/update-docs.ts
+++ b/tools/update-docs.ts
@@ -158,8 +158,12 @@ This rule was introduced in eslint-plugin-svelte ${await this.since}
 - [Test source](https://github.com/ota-meshi/eslint-plugin-svelte/blob/main/tests/src/rules/${ruleName}.ts)
 ${
   extensionRule
-    ? `
+    ? typeof extensionRule === "string"
+      ? `
 <sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/${extensionRule})</sup>
+`
+      : `
+<sup>Taken with ❤️ [from ${extensionRule.plugin}](${extensionRule.url})</sup>
 `
     : ""
 }`

--- a/tools/update-rules.ts
+++ b/tools/update-rules.ts
@@ -10,19 +10,30 @@ function camelCase(str: string) {
   return str.replace(/[-_](\w)/gu, (_, c) => (c ? c.toUpperCase() : ""))
 }
 
+/**
+ * Convert text to identifier
+ */
+function toIdentifier(str: string) {
+  const clean = str
+    .replace(/^[^\p{ID_Start}$_]/u, "")
+    .replace(/[^\p{ID_Continue}$\u200c\u200d]/gu, "-")
+
+  return camelCase(clean)
+}
+
 const content = `
 import type { RuleModule } from "../types"
 ${rules
   .map(
     (rule) =>
-      `import ${camelCase(rule.meta.docs.ruleName)} from "../rules/${
+      `import ${toIdentifier(rule.meta.docs.ruleName)} from "../rules/${
         rule.meta.docs.ruleName
       }"`,
   )
   .join("\n")}
 
 export const rules = [
-    ${rules.map((rule) => camelCase(rule.meta.docs.ruleName)).join(",")}
+    ${rules.map((rule) => toIdentifier(rule.meta.docs.ruleName)).join(",")}
 ] as RuleModule[]
 `
 


### PR DESCRIPTION
This PR adds `svelte/@typescript-eslint/no-unnecessary-condition` rule that extends `@typescript-eslint/no-unnecessary-condition` rule.

The new rule extends the `@typescript-eslint/no-unnecessary-condition` rule to fix false positives considering `$:` statements and HTML rendering.

I also made some changes to use full type information in the demo site.

---

close #254