### PR TITLE
chore: add migration guide from eslint-plugin-svelte3

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,5 +1,14 @@
 # Migration Guide
 
+## From `eslint-plugin-svelte3`
+
+You can not use both `eslint-plugin-svelte3` and `eslint-plugin-svelte` at same time.
+So before start to use this plugin, you need to remove `eslint-plugin-svelte3`'s stuff from both `package.json` and `.eslintrc.*`.
+
+> Note: If you want to know difference between `eslint-plugin-svelte` and `eslint-plugin-svelte3`, Please read the [reason](../#why).
+
+> Note: If you're using TypeScript, maybe you get `Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.` error at some configuration files.<br>In this case, please refer [this GitHub comment](https://github.com/typescript-eslint/typescript-eslint/issues/1723#issuecomment-626766041) to solve it.
+
 ## From `eslint-plugin-svelte` v1 To v2
 
 `eslint-plugin-svelte` v1 was an alias for [eslint-plugin-svelte3], but `eslint-plugin-svelte` v2 is now an independent eslint-plugin.
@@ -10,10 +19,10 @@ If you want the previous behavior, replace it with [eslint-plugin-svelte3].
 
 ## From `@ota-meshi/eslint-plugin-svelte`
 
-`@ota-meshi/eslint-plugin-svelte` has been renamed to `eslint-plugin-svelte`.  
+`@ota-meshi/eslint-plugin-svelte` has been renamed to `eslint-plugin-svelte`.\
 Therefore, you need to replace the package name, and the presets, rules, and settings specified in the configuration.
 
-- `package.json`  
+- `package.json`\
   Replace the package name.
 
   ```diff
@@ -21,8 +30,8 @@ Therefore, you need to replace the package name, and the presets, rules, and set
   +  "eslint-plugin-svelte": "^X.X.X"
   ```
 
-- `.eslintrc.*`  
-  Replace `@ota-meshi/svelte` with `svelte` as a string.  
+- `.eslintrc.*`\
+  Replace `@ota-meshi/svelte` with `svelte` as a string.\
   Examples:
 
   - Presets


### PR DESCRIPTION
fix: https://github.com/ota-meshi/eslint-plugin-svelte/issues/252

Honestly, I couldn't find difficulties in migrating from `eslint-plugin-svelte3`.
But preparing this section is essential for new users.
In the future, I will follow it up in the docs if some new user hits difficulties.

And I handled https://github.com/sveltejs/kit/issues/6847#issuecomment-1251471651 in the PR.