### PR TITLE
refactor: rename `settings.kit` to `settings.svelte.kit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,6 @@ See also <https://github.com/ota-meshi/svelte-eslint-parser#readme>.
 
 You can change the behavior of this plugin with some settings.
 
-- `ignoreWarnings` (optional) ... Specifies an array of rules that ignore reports in the template.  
-  For example, set rules on the template that cannot avoid false positives.
-- `compileOptions` (optional) ... Specifies options for Svelte compile. Effects rules that use Svelte compile. The target rules are [svelte/valid-compile](https://ota-meshi.github.io/eslint-plugin-svelte/rules/valid-compile/) and [svelte/no-unused-svelte-ignore](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore/). **Note that it has no effect on ESLint's custom parser**.
-  - `postcss` (optional) ... Specifies options related to PostCSS. You can disable the PostCSS process by specifying `false`.
-    - `configFilePath` (optional) ... Specifies the path of the directory containing the PostCSS configuration.
-
 e.g.
 
 ```js
@@ -210,13 +204,30 @@ module.exports = {
           configFilePath: "./path/to/my/postcss.config.js",
         },
       },
+      kit: {
+        files: {
+          routes: "src/routes",
+        },
+      },
     },
   },
   // ...
 }
 ```
 
-#### settings.kit
+#### settings.svelte.ignoreWarnings
+
+Specifies an array of rules that ignore reports in the template.  
+For example, set rules on the template that cannot avoid false positives.
+
+#### settings.svelte.compileOptions
+
+Specifies options for Svelte compile. Effects rules that use Svelte compile. The target rules are [svelte/valid-compile](https://ota-meshi.github.io/eslint-plugin-svelte/rules/valid-compile/) and [svelte/no-unused-svelte-ignore](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unused-svelte-ignore/). **Note that it has no effect on ESLint's custom parser**.
+
+- `postcss` ... Specifies options related to PostCSS. You can disable the PostCSS process by specifying `false`.
+  - `configFilePath` ... Specifies the path of the directory containing the PostCSS configuration.
+
+#### settings.svelte.kit
 
 If you use SvelteKit with not default configuration, you need to set below configurations.
 The schema is subset of SvelteKit's configuration.
@@ -228,9 +239,11 @@ e.g.
 module.exports = {
   // ...
   settings: {
-    kit: {
-      files: {
-        routes: "src/routes",
+    svelte: {
+      kit: {
+        files: {
+          routes: "src/routes",
+        },
       },
     },
   },
@@ -294,7 +307,7 @@ These rules relate to possible syntax or logic errors in Svelte code:
 | [svelte/no-shorthand-style-property-overrides](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-shorthand-style-property-overrides/) | disallow shorthand style properties that override related longhand properties | :star: |
 | [svelte/no-store-async](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-store-async/) | disallow using async/await inside svelte stores because it causes issues with the auto-unsubscribing features |  |
 | [svelte/no-unknown-style-directive-property](https://ota-meshi.github.io/eslint-plugin-svelte/rules/no-unknown-style-directive-property/) | disallow unknown `style:property` | :star: |
-| [svelte/require-store-callbacks-use-set-param](https://ota-meshi.github.io/eslint-plugin-svelte/rules/require-store-callbacks-use-set-param/) | (no description) |  |
+| [svelte/require-store-callbacks-use-set-param](https://ota-meshi.github.io/eslint-plugin-svelte/rules/require-store-callbacks-use-set-param/) | store callbacks must use `set` param |  |
 | [svelte/valid-compile](https://ota-meshi.github.io/eslint-plugin-svelte/rules/valid-compile/) | disallow warnings when compiling. | :star: |
 
 ## Security Vulnerability

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -25,7 +25,7 @@ These rules relate to possible syntax or logic errors in Svelte code:
 | [svelte/no-shorthand-style-property-overrides](./rules/no-shorthand-style-property-overrides.md) | disallow shorthand style properties that override related longhand properties | :star: |
 | [svelte/no-store-async](./rules/no-store-async.md) | disallow using async/await inside svelte stores because it causes issues with the auto-unsubscribing features |  |
 | [svelte/no-unknown-style-directive-property](./rules/no-unknown-style-directive-property.md) | disallow unknown `style:property` | :star: |
-| [svelte/require-store-callbacks-use-set-param](./rules/require-store-callbacks-use-set-param.md) | (no description) |  |
+| [svelte/require-store-callbacks-use-set-param](./rules/require-store-callbacks-use-set-param.md) | store callbacks must use `set` param |  |
 | [svelte/valid-compile](./rules/valid-compile.md) | disallow warnings when compiling. | :star: |
 
 ## Security Vulnerability

--- a/docs/rules/no-export-load-in-svelte-module-in-kit-pages.md
+++ b/docs/rules/no-export-load-in-svelte-module-in-kit-pages.md
@@ -20,9 +20,11 @@ And the API has changed.
 <script>
   const config = {
     settings: {
-      kit: {
-        files: {
-          routes: "",
+      svelte: {
+        kit: {
+          files: {
+            routes: "",
+          },
         },
       },
     },
@@ -49,7 +51,7 @@ And the API has changed.
 
 ## :wrench: Options
 
-Nothing. But if use are using not default routes folder, please set configuration according to the [user guide](../user-guide.md#settings-kit).
+Nothing. But if use are using not default routes folder, please set configuration according to the [user guide](../user-guide.md#settings-svelte-kit).
 
 ## :books: Further Reading
 

--- a/docs/rules/require-store-callbacks-use-set-param.md
+++ b/docs/rules/require-store-callbacks-use-set-param.md
@@ -7,7 +7,9 @@ description: "store callbacks must use `set` param"
 
 # svelte/require-store-callbacks-use-set-param
 
-> Store callbacks must use `set` param.
+> store callbacks must use `set` param
+
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
 
 ## :book: Rule Details
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -140,12 +140,6 @@ See also <https://github.com/ota-meshi/svelte-eslint-parser#readme>.
 
 You can change the behavior of this plugin with some settings.
 
-- `ignoreWarnings` (optional) ... Specifies an array of rules that ignore reports in the template.  
-  For example, set rules on the template that cannot avoid false positives.
-- `compileOptions` (optional) ... Specifies options for Svelte compile. Effects rules that use Svelte compile. The target rules are [svelte/valid-compile](./rules/valid-compile.md) and [svelte/no-unused-svelte-ignore](./rules/no-unused-svelte-ignore.md). **Note that it has no effect on ESLint's custom parser**.
-  - `postcss` (optional) ... Specifies options related to PostCSS. You can disable the PostCSS process by specifying `false`.
-    - `configFilePath` (optional) ... Specifies the path of the directory containing the PostCSS configuration.
-
 e.g.
 
 ```js
@@ -162,13 +156,30 @@ module.exports = {
           configFilePath: "./path/to/my/postcss.config.js",
         },
       },
+      kit: {
+        files: {
+          routes: "src/routes",
+        },
+      },
     },
   },
   // ...
 }
 ```
 
-#### settings.kit
+#### settings.svelte.ignoreWarnings
+
+Specifies an array of rules that ignore reports in the template.  
+For example, set rules on the template that cannot avoid false positives.
+
+#### settings.svelte.compileOptions
+
+Specifies options for Svelte compile. Effects rules that use Svelte compile. The target rules are [svelte/valid-compile](./rules/valid-compile.md) and [svelte/no-unused-svelte-ignore](./rules/no-unused-svelte-ignore.md). **Note that it has no effect on ESLint's custom parser**.
+
+- `postcss` ... Specifies options related to PostCSS. You can disable the PostCSS process by specifying `false`.
+  - `configFilePath` ... Specifies the path of the directory containing the PostCSS configuration.
+
+#### settings.svelte.kit
 
 If you use SvelteKit with not default configuration, you need to set below configurations.
 The schema is subset of SvelteKit's configuration.
@@ -180,9 +191,11 @@ e.g.
 module.exports = {
   // ...
   settings: {
-    kit: {
-      files: {
-        routes: "src/routes",
+    svelte: {
+      kit: {
+        files: {
+          routes: "src/routes",
+        },
       },
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,16 +121,16 @@ export type RuleContext = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ignore
   options: any[]
   settings?: {
-    ["svelte"]?: {
+    svelte?: {
       ignoreWarnings?: unknown
       compileOptions?: {
         babel?: boolean
         postcss?: false | { configFilePath?: unknown }
       }
-    }
-    ["kit"]?: {
-      files?: {
-        routes?: string
+      kit?: {
+        files?: {
+          routes?: string
+        }
       }
     }
   }

--- a/src/utils/svelte-kit.ts
+++ b/src/utils/svelte-kit.ts
@@ -19,7 +19,8 @@ export function isKitPageComponent(context: RuleContext): boolean {
   if (isRunOnBrowser) return true
   if (!hasSvelteKit(context.getFilename())) return false
   const routes =
-    context.settings?.kit?.files?.routes?.replace(/^\//, "") ?? "src/routes"
+    context.settings?.svelte?.kit?.files?.routes?.replace(/^\//, "") ??
+    "src/routes"
   const filePath = context.getFilename()
   const projectRootDir = getProjectRootDir(context.getFilename()) ?? ""
   return filePath.startsWith(path.join(projectRootDir, routes))

--- a/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/invalid/_config.json
+++ b/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/invalid/_config.json
@@ -1,8 +1,10 @@
 {
   "settings": {
-    "kit": {
-      "files": {
-        "routes": "tests/fixtures"
+    "svelte": {
+      "kit": {
+        "files": {
+          "routes": "tests/fixtures"
+        }
       }
     }
   }

--- a/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/valid/_config.json
+++ b/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/valid/_config.json
@@ -1,8 +1,10 @@
 {
   "settings": {
-    "kit": {
-      "files": {
-        "routes": "tests/fixtures"
+    "svelte": {
+      "kit": {
+        "files": {
+          "routes": "tests/fixtures"
+        }
       }
     }
   }

--- a/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/valid/not-page/_config.json
+++ b/tests/fixtures/rules/no-export-load-in-svelte-module-in-kit-pages/valid/not-page/_config.json
@@ -1,8 +1,10 @@
 {
   "settings": {
-    "kit": {
-      "files": {
-        "routes": "some-path"
+    "svelte": {
+      "kit": {
+        "files": {
+          "routes": "some-path"
+        }
       }
     }
   }


### PR DESCRIPTION
This PR renames the settings in `settings.kit` to `settings.svelte.kit`.
There is no convention for the namespace under `settings`, but it's common for the community to use the name of the plugin.
I didn't notice that in the reviews 😓.

cc: @baseballyama 
Sorry 😓. This also affects #283.


https://eslint.org/docs/latest/user-guide/configuring/configuration-files#adding-shared-settings