### PR TITLE
refactor: use `@typescript-eslint/scope-manager` instead of `eslint-scope`

### DIFF
--- a/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -182,7 +182,10 @@ export default createRule("@typescript-eslint/no-unnecessary-condition", {
       })
     }
 
-    const mutableVarReferenceIds: TSESTree.Identifier[] = []
+    const mutableVarReferenceIds: (
+      | TSESTree.Identifier
+      | TSESTree.JSXIdentifier
+    )[] = []
     const scriptElements: AST.SvelteScriptElement[] = []
     let inSvelteReactiveStatement = false
 

--- a/src/rules/prefer-destructured-store-props.ts
+++ b/src/rules/prefer-destructured-store-props.ts
@@ -78,13 +78,14 @@ export default createRule("prefer-destructured-store-props", {
 
       /** Checks whether the given node is reactive variable definition with member expression. */
       function isReactiveVariableDefinitionWithMemberExpression(
-        node: TSESTree.Identifier,
+        node: TSESTree.Identifier | TSESTree.JSXIdentifier,
       ): node is TSESTree.Identifier & {
         parent: TSESTree.MemberExpression & {
           parent: TSESTree.AssignmentExpression & { left: TSESTree.Identifier }
         }
       } {
         return (
+          node.type === "Identifier" &&
           node.parent?.type === "MemberExpression" &&
           node.parent.object === node &&
           getPropertyName(node.parent) === propName &&
@@ -101,13 +102,14 @@ export default createRule("prefer-destructured-store-props", {
 
       /** Checks whether the given node is reactive variable definition with destructuring. */
       function isReactiveVariableDefinitionWithDestructuring(
-        node: TSESTree.Identifier,
+        node: TSESTree.Identifier | TSESTree.JSXIdentifier,
       ): node is TSESTree.Identifier & {
         parent: TSESTree.AssignmentExpression & {
           left: TSESTree.ObjectPattern
         }
       } {
         return (
+          node.type === "Identifier" &&
           node.parent?.type === "AssignmentExpression" &&
           node.parent.right === node &&
           node.parent.left.type === "ObjectPattern" &&

--- a/src/rules/reference-helpers/svelte-store.ts
+++ b/src/rules/reference-helpers/svelte-store.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from "@typescript-eslint/types"
+import type { Variable } from "@typescript-eslint/scope-manager"
 import { ReferenceTracker } from "eslint-utils"
-import type { Variable } from "eslint-scope"
 import type { RuleContext } from "../../types"
 import type { TS, TSTools } from "../../utils/ts-utils"
 import { getTypeScriptTools } from "../../utils/ts-utils"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 import type { JSONSchema4 } from "json-schema"
-import type {
-  Linter,
-  Rule,
-  Scope,
-  SourceCode as ESLintSourceCode,
-} from "eslint"
+import type { Linter, Rule, SourceCode as ESLintSourceCode } from "eslint"
 import type { AST } from "svelte-eslint-parser"
 import type { TSESTree } from "@typescript-eslint/types"
+import type {
+  ScopeManager,
+  Scope,
+  Variable,
+} from "@typescript-eslint/scope-manager"
 import type {
   ASTNode,
   ASTNodeWithParent,
@@ -140,11 +140,11 @@ export type RuleContext = {
 
   getAncestors(): ASTNode[]
 
-  getDeclaredVariables(node: TSESTree.Node): Scope.Variable[]
+  getDeclaredVariables(node: TSESTree.Node): Variable[]
 
   getFilename(): string
 
-  getScope(): Scope.Scope
+  getScope(): Scope
 
   getSourceCode(): SourceCode
 
@@ -215,7 +215,7 @@ export interface SourceCode {
   lines: string[]
   hasBOM: boolean
   parserServices: ESLintSourceCode.ParserServices
-  scopeManager: Scope.ScopeManager
+  scopeManager: ScopeManager
   visitorKeys: ESLintSourceCode.VisitorKeys
 
   getText(node?: NodeOrToken, beforeCount?: number, afterCount?: number): string

--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -1,8 +1,8 @@
 import type { ASTNode, RuleContext, SourceCode } from "../types"
 import type { TSESTree } from "@typescript-eslint/types"
+import type { Scope, Variable } from "@typescript-eslint/scope-manager"
 import type { AST as SvAST } from "svelte-eslint-parser"
 import * as eslintUtils from "eslint-utils"
-import type { Scope } from "eslint"
 import voidElements from "./void-elements"
 
 /**
@@ -237,7 +237,7 @@ export function getLangValue(
 export function findVariable(
   context: RuleContext,
   node: TSESTree.Identifier,
-): Scope.Variable | null {
+): Variable | null {
   const initialScope = eslintUtils.getInnermostScope(
     getScope(context, node),
     node,
@@ -259,7 +259,7 @@ export function findVariable(
 export function getScope(
   context: RuleContext,
   currentNode: TSESTree.Node,
-): Scope.Scope {
+): Scope {
   const scopeManager = context.getSourceCode().scopeManager
 
   let node: TSESTree.Node | null = currentNode

--- a/typings/eslint-utils/index.d.ts
+++ b/typings/eslint-utils/index.d.ts
@@ -1,6 +1,7 @@
 import type { AST } from "svelte-eslint-parser"
-import type { Scope } from "eslint"
 import type { TSESTree } from "@typescript-eslint/types"
+import type { Scope } from "@typescript-eslint/scope-manager"
+import type { CALL, CONSTRUCT, ESM, READ } from "eslint-utils/referenceTracker"
 export {
   ReferenceTracker,
   TrackedReferences,
@@ -32,7 +33,7 @@ export function isNotClosingBraceToken(token: Token): boolean
 export function isNotCommentToken(token: Token): boolean
 
 export function findVariable(
-  initialScope: Scope.Scope,
+  initialScope: Scope,
   nameOrNode: TSESTree.Identifier | string,
 ): Scope.Variable
 
@@ -45,5 +46,46 @@ export function getPropertyName(
     | TSESTree.MethodDefinition
     | TSESTree.Property
     | TSESTree.PropertyDefinition,
-  initialScope?: Scope.Scope,
+  initialScope?: Scope,
 ): string | null
+
+/**
+ * Get the innermost scope which contains a given location.
+ */
+export function getInnermostScope(
+  initialScope: Scope,
+  node: TSESTree.Node,
+): Scope
+
+export class ReferenceTracker {
+  public static readonly CALL: typeof CALL
+
+  public static readonly CONSTRUCT: typeof CONSTRUCT
+
+  public static readonly ESM: typeof ESM
+
+  public static readonly READ: typeof READ
+
+  public constructor(globalScope: Scope, options?: ReferenceTrackerOptions)
+
+  /**
+   * Iterate the references of CommonJS modules.
+   */
+  public iterateCjsReferences<T = unknown>(
+    traceMap: TraceMap<T>,
+  ): IterableIterator<TrackedReferences<T>>
+
+  /**
+   * Iterate the references of ES modules.
+   */
+  public iterateEsmReferences<T = unknown>(
+    traceMap: TraceMap<T>,
+  ): IterableIterator<TrackedReferences<T>>
+
+  /**
+   * Iterate the references of global variables.
+   */
+  public iterateGlobalReferences<T = unknown>(
+    traceMap: TraceMap<T>,
+  ): IterableIterator<TrackedReferences<T>>
+}


### PR DESCRIPTION
This PR is a follow up to #294.
I forgot to migrate Scope related types.