### PR TITLE
fix `isKitPageComponent` on windows

### DIFF
--- a/.changeset/fix-isKitPageComponent-on-windows.md
+++ b/.changeset/fix-isKitPageComponent-on-windows.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix `isKitPageComponent` on windows

--- a/src/utils/svelte-kit.ts
+++ b/src/utils/svelte-kit.ts
@@ -23,7 +23,7 @@ export function isKitPageComponent(context: RuleContext): boolean {
     "src/routes"
   const filePath = context.getFilename()
   const projectRootDir = getProjectRootDir(context.getFilename()) ?? ""
-  const fileName = filePath.split("/").pop() || filePath
+  const fileName = path.basename(filePath)
   return (
     filePath.startsWith(path.join(projectRootDir, routes)) &&
     // MEMO: check only `+` and file extension for maintainability


### PR DESCRIPTION
it always returned `false` on windows because file paths are separated by `\` instead of `/`