### PR TITLE
allow `trailingSlash` in `valid-prop-names-in-kit-pages`

### DIFF
--- a/.changeset/support-trailingSlash.md
+++ b/.changeset/support-trailingSlash.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": minor
+---
+
+allow `trailingSlash` in `valid-prop-names-in-kit-pages`

--- a/src/rules/valid-prop-names-in-kit-pages.ts
+++ b/src/rules/valid-prop-names-in-kit-pages.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from "@typescript-eslint/types"
 import { createRule } from "../utils"
 import { isKitPageComponent } from "../utils/svelte-kit"
 
-const EXPECTED_PROP_NAMES = ["data", "errors"]
+const EXPECTED_PROP_NAMES = ["data", "errors", "trailingSlash"]
 
 export default createRule("valid-prop-names-in-kit-pages", {
   meta: {


### PR DESCRIPTION
fixes #319 