### PR TITLE
chore: fix playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,9 @@
     "yaml": "^2.1.1",
     "yarn-deduplicate": "^6.0.0"
   },
+  "resolutions": {
+    "rollup": "~3.6.0"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This PR works around the playground freezing issue.
The cause of the problem is a bug in rollup v3.7. The workaround is to use rollup v3.6 instead.

https://github.com/rollup/rollup/pull/4742
https://github.com/vitejs/vite/issues/11330

---

close #317 