### PR TITLE
chore: remove workaround for playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,9 +170,6 @@
     "yaml": "^2.1.1",
     "yarn-deduplicate": "^6.0.0"
   },
-  "resolutions": {
-    "rollup": "~3.6.0"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This PR reverts the #322 change. The workaround is no longer needed as the rollup has been fixed.