### PR TITLE
fix: types of `isOptionableExpression`

### DIFF
--- a/src/rules/@typescript-eslint/no-unnecessary-condition.ts
+++ b/src/rules/@typescript-eslint/no-unnecessary-condition.ts
@@ -700,9 +700,7 @@ export default createRule("@typescript-eslint/no-unnecessary-condition", {
     /**
      * Checks whether a lhs expression is optionable or not.
      */
-    function isOptionableExpression(
-      node: TSESTree.LeftHandSideExpression,
-    ): boolean {
+    function isOptionableExpression(node: TSESTree.Expression): boolean {
       const type = getNodeType(node)
       if (!type) {
         return false


### PR DESCRIPTION
I run `yarn build` on the latest main branch, but command failed due to type error.
Therefore I fixed it up.

```sh
baseballyama@baseballyama eslint-plugin-svelte % yarn build
yarn run v1.22.19
$ yarn clean
$ rimraf .nyc_output lib coverage build .svelte-kit svelte.config-dist.js
$ yarn build:ts
$ tsc --project ./tsconfig.build.json
src/rules/@typescript-eslint/no-unnecessary-condition.ts:749:34 - error TS2345: Argument of type 'ArrayExpression | ArrayPattern | ArrowFunctionExpression | AssignmentExpression | AwaitExpression | ... 35 more ... | YieldExpression' is not assignable to parameter of type 'LeftHandSideExpression'.
  Type 'AssignmentExpression' is not assignable to type 'LeftHandSideExpression'.
    Type 'AssignmentExpression' is missing the following properties from type 'TSTypeAssertion': typeAnnotation, expression

749       if (isOptionableExpression(nodeToCheck)) {
                                     ~~~~~~~~~~~


Found 1 error in src/rules/@typescript-eslint/no-unnecessary-condition.ts:749
```