### PR TITLE
chore: Enable user scroll even if mouse is on a Monaco editor

### DIFF
--- a/docs-svelte-kit/src/lib/eslint/MonacoEditor.svelte
+++ b/docs-svelte-kit/src/lib/eslint/MonacoEditor.svelte
@@ -98,6 +98,7 @@
       renderValidationDecorations: "on",
       renderWhitespace: "boundary",
       scrollBeyondLastLine: false,
+      scrollbar: { alwaysConsumeMouseWheel: false },
     }
 
     if (diffEditor) {


### PR DESCRIPTION
fix: https://github.com/ota-meshi/eslint-plugin-svelte/issues/331