### PR TITLE
  fix: false positives for `form` in `svelte/valid-prop-names-in-kit-pages`

### DIFF
--- a/.changeset/nice-buses-repeat.md
+++ b/.changeset/nice-buses-repeat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: false positives for `form` in `svelte/valid-prop-names-in-kit-pages`

--- a/src/rules/valid-prop-names-in-kit-pages.ts
+++ b/src/rules/valid-prop-names-in-kit-pages.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from "@typescript-eslint/types"
 import { createRule } from "../utils"
 import { isKitPageComponent } from "../utils/svelte-kit"
 
-const EXPECTED_PROP_NAMES = ["data", "errors"]
+const EXPECTED_PROP_NAMES = ["data", "errors", "form"]
 
 export default createRule("valid-prop-names-in-kit-pages", {
   meta: {

--- a/tests/fixtures/rules/valid-prop-names-in-kit-pages/valid/+test-for-form-input.svelte
+++ b/tests/fixtures/rules/valid-prop-names-in-kit-pages/valid/+test-for-form-input.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+  import type { PageData, ActionData } from "./$types"
+  export let form: ActionData
+</script>


### PR DESCRIPTION
fixes #344