### PR TITLE
[feat] Support `snapshot` to `valid-prop-names-in-kit-pages` rule

### DIFF
--- a/.changeset/yellow-games-double.md
+++ b/.changeset/yellow-games-double.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": minor
+---
+
+Support `snapshot` to `valid-prop-names-in-kit-pages` rule

--- a/docs/rules/valid-prop-names-in-kit-pages.md
+++ b/docs/rules/valid-prop-names-in-kit-pages.md
@@ -36,6 +36,8 @@ At SvelteKit v1.0.0-next.405, instead of having multiple props corresponding to 
   /** ✓ GOOD */
   export let data
   export let errors
+  export let form
+  export let snapshot
   // export let { data, errors } = { data: {}, errors: {} }
 
   /** ✗ BAD */

--- a/src/rules/valid-prop-names-in-kit-pages.ts
+++ b/src/rules/valid-prop-names-in-kit-pages.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from "@typescript-eslint/types"
 import { createRule } from "../utils"
 import { isKitPageComponent } from "../utils/svelte-kit"
 
-const EXPECTED_PROP_NAMES = ["data", "errors", "form"]
+const EXPECTED_PROP_NAMES = ["data", "errors", "form", "snapshot"]
 
 export default createRule("valid-prop-names-in-kit-pages", {
   meta: {

--- a/tests/fixtures/rules/valid-prop-names-in-kit-pages/valid/+test001-input.svelte
+++ b/tests/fixtures/rules/valid-prop-names-in-kit-pages/valid/+test001-input.svelte
@@ -1,6 +1,23 @@
 <script>
   export let data
   export let errors
+  export let form
+
+  let comment = ""
+
+  export const snapshot = {
+    capture: () => comment,
+    restore: (value) => (comment = value),
+  }
 </script>
 
 {data}, {errors}
+
+{#if form?.success}
+  <p>Successfully logged in! Welcome back, {data.user.name}</p>
+{/if}
+
+<form method="POST">
+  <textarea bind:value={comment} />
+  <button>Post comment</button>
+</form>


### PR DESCRIPTION
Recently, SvelteKit added snapshot feature.

https://kit.svelte.dev/docs/snapshots