### PR TITLE
fix: false positives for read property in `svelte/no-dom-manipulating`

### DIFF
--- a/.changeset/grumpy-gifts-repeat.md
+++ b/.changeset/grumpy-gifts-repeat.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: false positives for read property in `svelte/no-dom-manipulating`

--- a/src/rules/no-dom-manipulating.ts
+++ b/src/rules/no-dom-manipulating.ts
@@ -78,6 +78,8 @@ export default createRule("no-dom-manipulating", {
         if (parent.left !== target || !DOM_MANIPULATING_PROPERTIES.has(name)) {
           return
         }
+      } else {
+        return
       }
       context.report({
         node: member,

--- a/tests/fixtures/rules/no-dom-manipulating/valid/read-prop01-input.svelte
+++ b/tests/fixtures/rules/no-dom-manipulating/valid/read-prop01-input.svelte
@@ -1,0 +1,8 @@
+<script>
+  let divElement
+  let height = ""
+
+  $: if (divElement) height = `${divElement.clientHeight}px`
+</script>
+
+<div bind:this={divElement} />

--- a/tests/fixtures/rules/no-dom-manipulating/valid/read-prop02-input.svelte
+++ b/tests/fixtures/rules/no-dom-manipulating/valid/read-prop02-input.svelte
@@ -1,0 +1,8 @@
+<script>
+  let divElement
+  let foo = ""
+
+  $: if (divElement) foo = `${divElement.data.foo}`
+</script>
+
+<div bind:this={divElement} data-foo="Foo" />


### PR DESCRIPTION
close #378