### PR TITLE
chore: change lint-staged config

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,3 @@
 "use strict"
 
-module.exports = require("@1stg/lint-staged/tsc")
+module.exports = require("@1stg/lint-staged")


### PR DESCRIPTION
This PR changes the configuration of lint-staged.
The new configuration excludes typescript validation. Because it to take long. It is also done in CI so it is not always necessary.