### PR TITLE
fix: `ReferenceTracker` usage

### DIFF
--- a/.changeset/wet-books-travel.md
+++ b/.changeset/wet-books-travel.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-svelte": patch
+---
+
+fix: `ReferenceTracker` usage

--- a/src/rules/infinite-reactive-loop.ts
+++ b/src/rules/infinite-reactive-loop.ts
@@ -12,7 +12,9 @@ import { traverseNodes } from "svelte-eslint-parser"
 function extractTickReferences(
   context: RuleContext,
 ): { node: TSESTree.CallExpression; name: string }[] {
-  const referenceTracker = new ReferenceTracker(context.getScope())
+  const referenceTracker = new ReferenceTracker(
+    context.getSourceCode().scopeManager.globalScope!,
+  )
   const a = referenceTracker.iterateEsmReferences({
     svelte: {
       [ReferenceTracker.ESM]: true,
@@ -35,7 +37,9 @@ function extractTickReferences(
 function extractTaskReferences(
   context: RuleContext,
 ): { node: TSESTree.CallExpression; name: string }[] {
-  const referenceTracker = new ReferenceTracker(context.getScope())
+  const referenceTracker = new ReferenceTracker(
+    context.getSourceCode().scopeManager.globalScope!,
+  )
   const a = referenceTracker.iterateGlobalReferences({
     setTimeout: { [ReferenceTracker.CALL]: true },
     setInterval: { [ReferenceTracker.CALL]: true },

--- a/src/rules/reference-helpers/svelte-store.ts
+++ b/src/rules/reference-helpers/svelte-store.ts
@@ -13,7 +13,9 @@ export function* extractStoreReferences(
   context: RuleContext,
   storeNames: StoreName[] = ["writable", "readable", "derived"],
 ): Generator<{ node: TSESTree.CallExpression; name: string }, void> {
-  const referenceTracker = new ReferenceTracker(context.getScope())
+  const referenceTracker = new ReferenceTracker(
+    context.getSourceCode().scopeManager.globalScope!,
+  )
   for (const { node, path } of referenceTracker.iterateEsmReferences({
     "svelte/store": {
       [ReferenceTracker.ESM]: true,

--- a/src/rules/require-event-dispatcher-types.ts
+++ b/src/rules/require-event-dispatcher-types.ts
@@ -29,7 +29,9 @@ export default createRule("require-event-dispatcher-types", {
         if (!isTs) {
           return
         }
-        const referenceTracker = new ReferenceTracker(context.getScope())
+        const referenceTracker = new ReferenceTracker(
+          context.getSourceCode().scopeManager.globalScope!,
+        )
         for (const { node: n } of referenceTracker.iterateEsmReferences({
           svelte: {
             [ReferenceTracker.ESM]: true,


### PR DESCRIPTION

We were passing `context.getScope()` to the ReferenceTracker's constructor, which was not always correct, because the ReferenceTracker's constructor requires a Global scope.
Fix this PR to always pass a Global scope instance.

Without this change, https://github.com/ota-meshi/svelte-eslint-parser/pull/292 now returns the correct scopes, so the rules will not work properly.