### PR TITLE
fix syntax error in experimental-require-slot-types example

### DIFF
--- a/docs/rules/experimental-require-slot-types.md
+++ b/docs/rules/experimental-require-slot-types.md
@@ -36,7 +36,7 @@ The  `$$Slots` interface is experimental and is documented in [svelte RFC #38](h
 
 ```svelte
 <!-- ✓ GOOD -->
-<script>
+<script lang="ts">
   /* eslint svelte/experimental-require-slot-types: "error" */
 
   interface $$Slots {


### PR DESCRIPTION
this example was incorrectly in a javascript `script` block when it uses typescript syntax:

![image](https://user-images.githubusercontent.com/57028336/227090871-fde9ab5a-e909-4cf3-a0aa-6640eecf320b.png)
