### PR TITLE
docs: warn about the typescript parser being a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ module.exports = {
 
 See also <https://github.com/ota-meshi/svelte-eslint-parser#readme>.
 
+::: warning ❗ Attention
+
+The TypeScript parser uses a singleton internally and it will only use the
+options given to it when it was first initialized. If trying to change the
+options for a different file or override, the parser will simply ignore the new
+options (which may result in an error). See
+[typescript-eslint/typescript-eslint#6778](https://github.com/typescript-eslint/typescript-eslint/issues/6778)
+for some context.
+
+:::
+
 #### settings.svelte
 
 You can change the behavior of this plugin with some settings.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,6 +137,17 @@ module.exports = {
 
 See also <https://github.com/ota-meshi/svelte-eslint-parser#readme>.
 
+::: warning ❗ Attention
+
+The TypeScript parser uses a singleton internally and it will only use the
+options given to it when it was first initialized. If trying to change the
+options for a different file or override, the parser will simply ignore the new
+options (which may result in an error). See
+[typescript-eslint/typescript-eslint#6778](https://github.com/typescript-eslint/typescript-eslint/issues/6778)
+for some context.
+
+:::
+
 #### settings.svelte
 
 You can change the behavior of this plugin with some settings.


### PR DESCRIPTION
The TypeScript parser uses a singleton internally, which means that repeated `parserOptions` will be ignored, using only the first one. This can lead to unexpected behaviour if there are multiple possible configurations.

This closes #422.

Ref: #422